### PR TITLE
Use correct name of config file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,8 @@ Whosthere can be configured via a YAML configuration file.
 By default, it looks for the configuration file in the following order:
 
 - Path specified in the `WHOSTHERE_CONFIG` environment variable (if set)
-- `$XDG_CONFIG_HOME/whosthere/whosthere.yaml` (if `XDG_CONFIG_HOME` is set)
-- `~/.config/whosthere/whosthere.yaml` (otherwise)
+- `$XDG_CONFIG_HOME/whosthere/config.yaml` (if `XDG_CONFIG_HOME` is set)
+- `~/.config/whosthere/config.yaml` (otherwise)
 
 When not running in TUI mode, logs are also written to the console output.
 


### PR DESCRIPTION
Hi, thanks for the useful tool!

Using `0.2.0`, I had trouble getting my config file picked up unless I specifically passed its path. Then I noticed that the name of the default config file as specified in the code is different than what the README mentions:
https://github.com/ramonvermeulen/whosthere/blob/32ed3ee01d1e71efaabc53e5eb1e6587f6d80f27/internal/core/config/loader.go#L16

https://github.com/ramonvermeulen/whosthere/blob/32ed3ee01d1e71efaabc53e5eb1e6587f6d80f27/README.md?plain=1#L112-L113

Renaming my config file to `config.yaml` makes it work for me, so this changes the README to use that name as well.