### PR TITLE
fix: replace CGO clipboard with portable go-clipboard library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ deps:
 default: deps fmt lint install test
 
 build:
-	CGO_ENABLED=1 go build -ldflags '$(LDFLAGS)' -o $(APP_NAME) .
+	CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o $(APP_NAME) .
 
 install: build
-	CGO_ENABLED=1 go install -v ./...
+	CGO_ENABLED=0 go install -v ./...
 
 lint:
 	golangci-lint run

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/ramonvermeulen/whosthere
 go 1.25.4
 
 require (
+	github.com/dece2183/go-clipboard v1.0.0
 	github.com/gdamore/tcell/v2 v2.13.7
 	github.com/goccy/go-yaml v1.19.2
 	github.com/rivo/tview v0.42.0
 	github.com/spf13/cobra v1.10.2
 	go.uber.org/zap v1.27.1
-	golang.design/x/clipboard v0.7.1
 	golang.org/x/net v0.49.0
 	golang.org/x/sys v0.40.0
 )
@@ -20,9 +20,6 @@ require (
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 // indirect
-	golang.org/x/image v0.28.0 // indirect
-	golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f // indirect
 	golang.org/x/term v0.39.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dece2183/go-clipboard v1.0.0 h1:EL7UDpJyIYa8AIznhY8lR6tE1H6vYIlTSDt+17dNprM=
+github.com/dece2183/go-clipboard v1.0.0/go.mod h1:nJZS6An1kHc8CxKAgUX3IF1wtDcbpunPkYFn4U3qhtE=
 github.com/gdamore/encoding v1.0.1 h1:YzKZckdBL6jVt2Gc+5p82qhrGiqMdG/eNs6Wy0u3Uhw=
 github.com/gdamore/encoding v1.0.1/go.mod h1:0Z0cMFinngz9kS1QfMjCP8TY7em3bZYeeklsSDPivEo=
 github.com/gdamore/tcell/v2 v2.13.7 h1:yfHdeC7ODIYCc6dgRos8L1VujQtXHmUpU6UZotzD6os=
@@ -33,16 +35,8 @@ go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN8
 go.uber.org/zap v1.27.1 h1:08RqriUEv8+ArZRYSTXy1LeBScaMpVSTBhCeaZYfMYc=
 go.uber.org/zap v1.27.1/go.mod h1:GB2qFLM7cTU87MWRP2mPIjqfIDnGu+VIO4V/SdhGo2E=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
-golang.design/x/clipboard v0.7.1 h1:OEG3CmcYRBNnRwpDp7+uWLiZi3hrMRJpE9JkkkYtz2c=
-golang.design/x/clipboard v0.7.1/go.mod h1:i5SiIqj0wLFw9P/1D7vfILFK0KHMk7ydE72HRrUIgkg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
-golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476 h1:Wdx0vgH5Wgsw+lF//LJKmWOJBLWX6nprsMqnf99rYDE=
-golang.org/x/exp/shiny v0.0.0-20250606033433-dcc06ee1d476/go.mod h1:ygj7T6vSGhhm/9yTpOQQNvuAUFziTH7RUiH74EoE2C8=
-golang.org/x/image v0.28.0 h1:gdem5JW1OLS4FbkWgLO+7ZeFzYtL3xClb97GaUzYMFE=
-golang.org/x/image v0.28.0/go.mod h1:GUJYXtnGKEUgggyzh+Vxt+AviiCcyiwpsl8iQ8MvwGY=
-golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f h1:/n+PL2HlfqeSiDCuhdBbRNlGS/g2fM4OHufalHaTVG8=
-golang.org/x/mobile v0.0.0-20250606033058-a2a15c67f36f/go.mod h1:ESkJ836Z6LpG6mTVAhA48LpfW/8fNR0ifStlH2axyfg=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=


### PR DESCRIPTION
The old clipboard library (golang.design/x/clipboard) required CGO and X11
headers at build time, and didn't support Wayland. This made builds fail on
Wayland-only systems.

**Error before fix:**
```
➜ go install github.com/ramonvermeulen/whosthere@latest
# golang.design/x/clipboard
clipboard_linux.c:14:10: fatal error: X11/Xlib.h: No such file or directory
   14 | #include <X11/Xlib.h>
      |          ^~~~~~~~~~~~
compilation terminated.
```

Switched to github.com/dece2183/go-clipboard which is pure Go and handles
both X11 (xclip/xsel) and Wayland (wl-copy) at runtime.

Removed the internal clipboard package and updated the app to use the new API.
Changed Makefile to build with CGO_ENABLED=0 since we no longer need CGO.