### PR TITLE
feat: add `arm` (32 bit) v6 + v7 as build targets

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,7 +10,11 @@ builds:
   - main: ./main.go
     binary: whosthere
     goos: ["linux", "darwin", "windows"]
-    goarch: ["386", "amd64", "arm64"]
+    goarch: ["386", "amd64", "arm64", "arm"]
+    goarm: ["6", "7"]
+    ignore:
+      - goos: windows
+        goarch: arm
     ldflags:
       - -s -w -X main.versionStr={{.Version}}
       - -X main.commitStr={{ .Commit }}

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,10 @@ LDFLAGS := -s -w \
 	-X main.commitStr=$(GIT_COMMIT) \
 	-X main.dateStr=$(BUILD_DATE)
 
+all: dev-deps fmt lint test build release-clean
+
 # TODO: add cross-platform deps support
-deps:
+dev-deps:
 	go mod tidy
 	pipx install mdformat
 	pipx inject mdformat mdformat-gfm
@@ -19,8 +21,6 @@ deps:
 	brew install goreleaser
 	brew install golangci-lint
 	brew upgrade golangci-lint
-
-default: deps fmt lint install test release-clean
 
 build:
 	CGO_ENABLED=0 go build -ldflags '$(LDFLAGS)' -o $(APP_NAME) .


### PR DESCRIPTION
Closes https://github.com/ramonvermeulen/whosthere/issues/51

- adds `arm` as build target to the `.goreleaser` so that from next release onwards arm 32 bit v6 + v7 will be included.