### PR TITLE
feat: add MAC address copy functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Whosthere is supported on the following platforms:
 | `g`                | Go to top                  |
 | `G`                | Go to bottom               |
 | `y`                | Copy IP of selected device |
+| `Y`                | Copy MAC of selected device|
 | `enter`            | Show device details        |
 | `CTRL+t`           | Toggle theme selector      |
 | `CTRL+c`           | Stop application           |

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -308,6 +308,21 @@ func (a *App) handleEvents() {
 					zap.L().Warn("failed to copy to clipboard", zap.Error(err))
 				}
 			}
+		case events.CopyMac:
+			var mac string
+			if event.MAC != "" {
+				mac = event.MAC
+			} else {
+				device, ok := a.state.Selected()
+				if ok {
+					mac = device.MAC
+				}
+			}
+			if mac != "" {
+				if err := a.clipboard.CopyText(mac); err != nil {
+					zap.L().Warn("failed to copy to clipboard", zap.Error(err))
+				}
+			}
 		}
 		a.rerenderVisibleViews()
 	}

--- a/internal/ui/components/device_table.go
+++ b/internal/ui/components/device_table.go
@@ -80,6 +80,12 @@ func (dt *DeviceTable) handleNormalKey(ev *tcell.EventKey) *tcell.EventKey {
 			dt.emit(events.CopyIP{IP: ip})
 		}
 		return nil
+	case ev.Rune() == 'Y':
+		mac := dt.SelectedMAC()
+		if mac != "" {
+			dt.emit(events.CopyMac{MAC: mac})
+		}
+		return nil
 	default:
 		return ev
 	}
@@ -169,6 +175,16 @@ func (dt *DeviceTable) SelectedIP() string {
 	if cell == nil {
 		return ""
 	}
+	return cell.Text
+}
+
+// SelectedMAC returns the MAC for the currently selected row, if any.
+func (dt *DeviceTable) SelectedMAC() string {
+	row, _ := dt.GetSelection()
+	if row <= 0 {
+		return ""
+	}
+	cell := dt.GetCell(row, 2)
 	return cell.Text
 }
 

--- a/internal/ui/events/events.go
+++ b/internal/ui/events/events.go
@@ -62,3 +62,8 @@ type SearchFinished struct{}
 type CopyIP struct {
 	IP string
 }
+
+// CopyMac is emitted to copy the MAC to clipboard.
+type CopyMac struct {
+	MAC string
+}

--- a/internal/ui/views/dashboard.go
+++ b/internal/ui/views/dashboard.go
@@ -34,7 +34,7 @@ func NewDashboardView(emit func(events.Event), queue func(f func())) *DashboardV
 
 	statusBar := components.NewStatusBar()
 	statusBar.Spinner().SetSuffix(" Discovering Devices...")
-	statusBar.SetHelp("j/k: up/down" + components.Divider + "g/G: top/bottom" + components.Divider + "y: Copy IP" + components.Divider + "Enter: details" + components.Divider + "Ctrl+T: theme")
+	statusBar.SetHelp("j/k: up/down" + components.Divider + "g/G: top/bottom" + components.Divider + "y/Y: Copy IP/MAC" + components.Divider + "Enter: details" + components.Divider + "Ctrl+T: theme")
 
 	filterBar := components.NewFilterBar()
 

--- a/internal/ui/views/detail.go
+++ b/internal/ui/views/detail.go
@@ -37,7 +37,7 @@ func NewDetailView(emit func(events.Event), queue func(f func())) *DetailView {
 		SetTitle(" Details ")
 
 	statusBar := components.NewStatusBar()
-	statusBar.SetHelp("Esc/q: Back" + components.Divider + "y: Copy IP" + components.Divider + "p: Port Scan")
+	statusBar.SetHelp("Esc/q: Back" + components.Divider + "y/Y: Copy IP/MAC" + components.Divider + "p: Port Scan")
 
 	main.AddItem(header, 1, 0, false)
 	main.AddItem(info, 0, 1, true)
@@ -74,6 +74,9 @@ func handleInput(p *DetailView) func(ev *tcell.EventKey) *tcell.EventKey {
 			return nil
 		case ev.Rune() == 'y':
 			p.emit(events.CopyIP{})
+			return nil
+		case ev.Rune() == 'Y':
+			p.emit(events.CopyMac{})
 			return nil
 		default:
 			return ev


### PR DESCRIPTION
Add ability to copy MAC address using Shift+Y key binding, mirroring the existing IP copy functionality (y key).

Closes #50