### PR TITLE
fix: use different `route.RIBType` when reading arp cache on FreeBSD

### DIFF
--- a/internal/core/discovery/arp/darwin_cache_reader.go
+++ b/internal/core/discovery/arp/darwin_cache_reader.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"runtime"
 
 	"github.com/ramonvermeulen/whosthere/internal/core/discovery"
 	"golang.org/x/net/route"
@@ -24,7 +25,14 @@ func (s *Scanner) readDarwinARPCache(ctx context.Context, out chan<- discovery.D
 }
 
 func (s *Scanner) readDarwinARPCacheRaw() ([]Entry, error) {
-	b, err := route.FetchRIB(unix.AF_INET, route.RIBTypeRoute, 0)
+	var ribType route.RIBType
+	if runtime.GOOS == "freebsd" {
+		ribType = unix.NET_RT_FLAGS
+	} else {
+		ribType = route.RIBTypeRoute
+	}
+
+	b, err := route.FetchRIB(unix.AF_INET, ribType, 0)
 	if err != nil {
 		return nil, fmt.Errorf("route.FetchRIB: %w", err)
 	}


### PR DESCRIPTION
An user contacted me that no devices appeared while running `whosthere` on FreeBSD. After some debugging I resolved the issue on a VM with bridged networking by changing the `route.RIBType` on FreeBSD to `unix.NET_RT_FLAGS`.