### PR TITLE
feat(interface): add the ability to switch the network interface at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ whosthere --help
 | `Y`                | Copy MAC of selected device |
 | `enter`            | Show device details         |
 | `CTRL+t`           | Toggle theme selector       |
+| `CTRL+i`           | Toggle interface selector   |
 | `CTRL+c`/`q`       | Stop application            |
 | `ESC`              | Clear search / Go back      |
 | `p` (details view) | Start port scan on device   |
@@ -139,6 +140,11 @@ Whosthere looks for the configuration file in the following order, using the fir
 ```yaml
 # Uncomment the next line to configure a specific network interface - uses OS default if not set
 # network_interface: eth0
+
+# When enabled, devices from all network interfaces are shown and persist when switching interfaces
+# Note: if two interfaces share the same subnet (e.g. both use 192.168.1.x), devices may get merged
+# since they are identified by IP address. Use with caution on overlapping subnets.
+all_interfaces: false
 
 # How often to run discovery scans
 scan_interval: 20s

--- a/internal/core/config/config.go
+++ b/internal/core/config/config.go
@@ -26,6 +26,7 @@ var DefaultTCPPorts = []int{21, 22, 23, 25, 80, 110, 135, 139, 143, 389, 443, 44
 // Config captures all configurable parameters for the application.
 type Config struct {
 	NetworkInterface string        `yaml:"network_interface"`
+	AllInterfaces    bool          `yaml:"all_interfaces"`
 	ScanInterval     time.Duration `yaml:"scan_interval"`
 	// ScanDuration is deprecated.
 	//
@@ -92,9 +93,10 @@ type ThemeConfig struct {
 // These defaults are used if no config is provided by the user.
 func DefaultConfig() *Config {
 	return &Config{
-		ScanInterval: discovery.DefaultScanInterval,
-		ScanDuration: discovery.DefaultScanTimeout,
-		ScanTimeout:  discovery.DefaultScanTimeout,
+		AllInterfaces: false,
+		ScanInterval:  discovery.DefaultScanInterval,
+		ScanDuration:  discovery.DefaultScanTimeout,
+		ScanTimeout:   discovery.DefaultScanTimeout,
 		Scanners: ScannerConfig{
 			MDNS: ScannerToggle{Enabled: true},
 			SSDP: ScannerToggle{Enabled: true},

--- a/internal/core/config/settings.go
+++ b/internal/core/config/settings.go
@@ -101,6 +101,25 @@ func GlobalSettings() []GlobalSetting {
 			},
 		},
 		{
+			YAMLKey:  "all_interfaces",
+			FlagName: "all-interfaces",
+			Usage:    "Show devices from all network interfaces instead of only the active one (e.g. --all-interfaces)",
+			Type:     FlagTypeBool,
+			Sources:  all,
+			Set: func(c *Config, v string) error {
+				b, err := parseBool(v)
+				if err != nil {
+					return err
+				}
+				c.AllInterfaces = b
+				return nil
+			},
+			Get: func(c *Config) any { return c.AllInterfaces },
+			Doc: YAMLDoc{
+				Comment: "When enabled, devices from all network interfaces are shown and persist when switching interfaces\nNote: if two interfaces share the same subnet (e.g. both use 192.168.1.x), devices may get merged\nsince they are identified by IP address. Use with caution on overlapping subnets.",
+			},
+		},
+		{
 			YAMLKey:  "scan_interval",
 			FlagName: "interval",
 			Short:    "n",

--- a/internal/core/config/settings_test.go
+++ b/internal/core/config/settings_test.go
@@ -35,6 +35,16 @@ func getSettingTestCases() []settingTestCase {
 			expectedYAML: "en0",
 		},
 		{
+			yamlKey:      "all_interfaces",
+			envVar:       "WHOSTHERE__ALL_INTERFACES",
+			envValue:     "true",
+			expectedEnv:  true,
+			flagValue:    "true",
+			expectedFlag: true,
+			yamlValue:    "true",
+			expectedYAML: true,
+		},
+		{
 			yamlKey:      "scan_timeout",
 			envVar:       "WHOSTHERE__SCAN_TIMEOUT",
 			envValue:     "15s",
@@ -476,6 +486,7 @@ func TestFullYAMLConfig_LoadFromFile(t *testing.T) {
 	// 2. It's already tested in individual setting tests (env/flag/yaml)
 	// 3. This test focuses on the full loading path, not individual field validation
 	fullYAML := `
+all_interfaces: true
 scan_timeout: 12s
 scan_interval: 45s
 
@@ -532,6 +543,7 @@ theme:
 		got      any
 		expected any
 	}{
+		{"all_interfaces", cfg.AllInterfaces, true},
 		{"scan_timeout", cfg.ScanTimeout, 12 * time.Second},
 		{"scan_interval", cfg.ScanInterval, 45 * time.Second},
 		{"scanners.mdns.enabled", cfg.Scanners.MDNS.Enabled, false},

--- a/internal/core/engine_builder.go
+++ b/internal/core/engine_builder.go
@@ -44,7 +44,7 @@ func BuildEngine(cfg *config.Config, logger discovery.Logger) (*discovery.Engine
 		scanners = append(scanners, s)
 	}
 	if cfg.Scanners.ARP.Enabled {
-		s, err := arp.New(iface, arp.WithLogger(logger))
+		s, err := arp.New(iface, arp.WithLogger(logger), arp.WithAllInterfaces(cfg.AllInterfaces))
 		if err != nil {
 			return nil, err
 		}

--- a/internal/core/state/state.go
+++ b/internal/core/state/state.go
@@ -27,6 +27,7 @@ type ReadOnly interface {
 	SearchText() string
 	SearchError() bool
 	NoColor() bool
+	CurrentInterface() string
 }
 
 // AppState holds application-level state shared across views and
@@ -34,17 +35,18 @@ type ReadOnly interface {
 type AppState struct {
 	mu sync.RWMutex
 
-	devices        map[string]*discovery.Device
-	selectedIP     string
-	previousTheme  string
-	version        string
-	filterPattern  string
-	isDiscovering  bool
-	isPortscanning bool
-	cfg            *config.Config
-	searchError    bool
-	searchActive   bool
-	noColor        bool
+	devices          map[string]*discovery.Device
+	selectedIP       string
+	previousTheme    string
+	version          string
+	filterPattern    string
+	isDiscovering    bool
+	isPortscanning   bool
+	cfg              *config.Config
+	searchError      bool
+	searchActive     bool
+	noColor          bool
+	currentInterface string
 }
 
 func NewAppState(cfg *config.Config, version string) *AppState {
@@ -274,3 +276,26 @@ func (s *AppState) NoColor() bool {
 	defer s.mu.RUnlock()
 	return s.noColor
 }
+
+// CurrentInterface returns the active network interface name.
+func (s *AppState) CurrentInterface() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.currentInterface
+}
+
+// SetCurrentInterface sets the active network interface name.
+func (s *AppState) SetCurrentInterface(name string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.currentInterface = name
+}
+
+// ClearDevices removes all discovered devices and resets selection.
+func (s *AppState) ClearDevices() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.devices = make(map[string]*discovery.Device)
+	s.selectedIP = ""
+}
+

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -41,8 +42,13 @@ type App struct {
 	isReady       bool
 	clipboard     *clipboard.Clipboard
 	logger        *slog.Logger
-	engineCancel  context.CancelFunc
-	engineMu      sync.Mutex
+
+	// Engine lifecycle management for runtime interface switching.
+	// When the user switches network interface, the old engine must stop cleanly
+	// and the new one must start without any stale device data leaking through.
+	engineCancel context.CancelFunc // cancels the context of the active handleEngineEvents goroutine
+	engineMu     sync.Mutex         // prevents concurrent interface switches from racing on shared state
+	engineGen    atomic.Uint64      // generation counter; old goroutines compare against this before upserting devices
 }
 
 func NewApp(cfg *config.Config, logger *slog.Logger, version string) (*App, error) {
@@ -129,8 +135,9 @@ func (a *App) Run() error {
 	if a.engine != nil && a.cfg != nil {
 		ctx, cancel := context.WithCancel(context.Background())
 		a.engineCancel = cancel
+		gen := a.engineGen.Add(1)
 		a.engine.Start(context.Background())
-		go a.handleEngineEvents(ctx, a.engine)
+		go a.handleEngineEvents(ctx, a.engine, gen)
 	}
 
 	return a.Application.Run()
@@ -193,8 +200,8 @@ func (a *App) startUIRefreshLoop() {
 }
 
 // handleEngineEvents processes events from a specific engine instance.
-// It exits when the context is cancelled or the engine's Events channel is closed.
-func (a *App) handleEngineEvents(ctx context.Context, engine *discovery.Engine) {
+// It exits when the context is cancelled, the generation changes, or the channel closes.
+func (a *App) handleEngineEvents(ctx context.Context, engine *discovery.Engine, gen uint64) {
 	defer func() {
 		if r := recover(); r != nil {
 			a.logger.Error("panic in handleEngineEvents", "panic", r)
@@ -202,7 +209,7 @@ func (a *App) handleEngineEvents(ctx context.Context, engine *discovery.Engine) 
 	}()
 
 	for event := range engine.Events {
-		if ctx.Err() != nil {
+		if ctx.Err() != nil || a.engineGen.Load() != gen {
 			return
 		}
 		switch event.Type {
@@ -211,7 +218,7 @@ func (a *App) handleEngineEvents(ctx context.Context, engine *discovery.Engine) 
 		case discovery.EventScanCompleted:
 			a.emit(events.DiscoveryStopped{})
 		case discovery.EventDeviceDiscovered:
-			if event.Device != nil {
+			if event.Device != nil && a.engineGen.Load() == gen {
 				a.state.UpsertDevice(event.Device)
 			}
 		case discovery.EventError:
@@ -398,6 +405,8 @@ func (a *App) switchInterface(name string) {
 		a.engineCancel()
 	}
 
+	gen := a.engineGen.Add(1)
+
 	if a.engine != nil {
 		oldEngine := a.engine
 		go oldEngine.Stop()
@@ -424,6 +433,5 @@ func (a *App) switchInterface(name string) {
 	a.engineCancel = cancel
 
 	a.engine.Start(context.Background())
-	go a.handleEngineEvents(ctx, engine)
+	go a.handleEngineEvents(ctx, engine, gen)
 }
-

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -47,7 +47,7 @@ type App struct {
 	// When the user switches network interface, the old engine must stop cleanly
 	// and the new one must start without any stale device data leaking through.
 	engineCancel context.CancelFunc // cancels the context of the active handleEngineEvents goroutine
-	engineMu     sync.Mutex         // prevents concurrent interface switches from racing on shared state
+	engineMu     sync.RWMutex       // write-locked during interface switch, read-locked during device upsert
 	engineGen    atomic.Uint64      // generation counter; old goroutines compare against this before upserting devices
 }
 
@@ -218,8 +218,12 @@ func (a *App) handleEngineEvents(ctx context.Context, engine *discovery.Engine, 
 		case discovery.EventScanCompleted:
 			a.emit(events.DiscoveryStopped{})
 		case discovery.EventDeviceDiscovered:
-			if event.Device != nil && a.engineGen.Load() == gen {
-				a.state.UpsertDevice(event.Device)
+			if event.Device != nil {
+				a.engineMu.RLock()
+				if a.engineGen.Load() == gen {
+					a.state.UpsertDevice(event.Device)
+				}
+				a.engineMu.RUnlock()
 			}
 		case discovery.EventError:
 			a.emit(events.DiscoveryStopped{})
@@ -410,6 +414,7 @@ func (a *App) switchInterface(name string) {
 	if a.engine != nil {
 		oldEngine := a.engine
 		go oldEngine.Stop()
+		time.Sleep(50 * time.Millisecond)
 	}
 
 	if !a.cfg.AllInterfaces {
@@ -419,6 +424,7 @@ func (a *App) switchInterface(name string) {
 	a.rerenderVisibleViews()
 
 	a.cfg.NetworkInterface = name
+
 	engine, err := core.BuildEngine(a.cfg, a.logger)
 	if err != nil {
 		a.logger.Error("failed to build engine for interface", "interface", name, "error", err)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -403,7 +403,9 @@ func (a *App) switchInterface(name string) {
 		go oldEngine.Stop()
 	}
 
-	a.state.ClearDevices()
+	if !a.cfg.AllInterfaces {
+		a.state.ClearDevices()
+	}
 	a.state.SetIsDiscovering(false)
 	a.rerenderVisibleViews()
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -41,6 +41,8 @@ type App struct {
 	isReady       bool
 	clipboard     *clipboard.Clipboard
 	logger        *slog.Logger
+	engineCancel  context.CancelFunc
+	engineMu      sync.Mutex
 }
 
 func NewApp(cfg *config.Config, logger *slog.Logger, version string) (*App, error) {
@@ -76,6 +78,7 @@ func NewApp(cfg *config.Config, logger *slog.Logger, version string) (*App, erro
 	a.engine = engine
 	// todo(ramon) handle in BuildEngine -> WithPortScanner(...)
 	a.portScanner = discovery.NewPortScanner(100, engine.Iface)
+	a.state.SetCurrentInterface(engine.Iface.Interface.Name)
 
 	app.SetRoot(a.pages, true)
 	app.SetInputCapture(a.handleGlobalKeys)
@@ -124,8 +127,10 @@ func (a *App) Run() error {
 	}
 
 	if a.engine != nil && a.cfg != nil {
+		ctx, cancel := context.WithCancel(context.Background())
+		a.engineCancel = cancel
 		a.engine.Start(context.Background())
-		go a.handleEngineEvents()
+		go a.handleEngineEvents(ctx, a.engine)
 	}
 
 	return a.Application.Run()
@@ -137,12 +142,14 @@ func (a *App) setupPages(cfg *config.Config) {
 	splashPage := views.NewSplashView(a.emit)
 	themePickerModal := views.NewThemeModalView(a.emit)
 	portScanModal := views.NewPortScanModalView(a.emit)
+	interfacePickerModal := views.NewInterfaceModalView(a.emit)
 
 	a.pages.AddPage(routes.RouteDashboard, dashboardPage, true, false)
 	a.pages.AddPage(routes.RouteDetail, detailPage, true, false)
 	a.pages.AddPage(routes.RouteSplash, splashPage, true, false)
 	a.pages.AddPage(routes.RouteThemePicker, themePickerModal, true, false)
 	a.pages.AddPage(routes.RoutePortScan, portScanModal, true, false)
+	a.pages.AddPage(routes.RouteInterfacePicker, interfacePickerModal, true, false)
 
 	initialPage := routes.RouteDashboard
 	if cfg != nil && cfg.Splash.Enabled {
@@ -158,6 +165,9 @@ func (a *App) handleGlobalKeys(event *tcell.EventKey) *tcell.EventKey {
 	switch event.Key() {
 	case tcell.KeyCtrlT:
 		a.emit(events.NavigateTo{Route: routes.RouteThemePicker, Overlay: true})
+		return nil
+	case tcell.KeyCtrlI:
+		a.emit(events.NavigateTo{Route: routes.RouteInterfacePicker, Overlay: true})
 		return nil
 	case tcell.KeyRune:
 		if event.Rune() == 'q' || event.Rune() == 'Q' {
@@ -182,14 +192,19 @@ func (a *App) startUIRefreshLoop() {
 	}()
 }
 
-func (a *App) handleEngineEvents() {
+// handleEngineEvents processes events from a specific engine instance.
+// It exits when the context is cancelled or the engine's Events channel is closed.
+func (a *App) handleEngineEvents(ctx context.Context, engine *discovery.Engine) {
 	defer func() {
 		if r := recover(); r != nil {
 			a.logger.Error("panic in handleEngineEvents", "panic", r)
 		}
 	}()
 
-	for event := range a.engine.Events {
+	for event := range engine.Events {
+		if ctx.Err() != nil {
+			return
+		}
 		switch event.Type {
 		case discovery.EventScanStarted:
 			a.emit(events.DiscoveryStarted{})
@@ -343,6 +358,8 @@ func (a *App) handleEvents() {
 					a.logger.Warn("failed to copy to clipboard", "error", err)
 				}
 			}
+		case events.InterfaceSelected:
+			go a.switchInterface(event.Name)
 		}
 		a.rerenderVisibleViews()
 	}
@@ -372,3 +389,39 @@ func (a *App) startPortscan() {
 	device.SetOpenPorts(openPorts)
 	a.emit(events.PortScanStopped{})
 }
+
+func (a *App) switchInterface(name string) {
+	a.engineMu.Lock()
+	defer a.engineMu.Unlock()
+
+	if a.engineCancel != nil {
+		a.engineCancel()
+	}
+
+	if a.engine != nil {
+		oldEngine := a.engine
+		go oldEngine.Stop()
+	}
+
+	a.state.ClearDevices()
+	a.state.SetIsDiscovering(false)
+	a.rerenderVisibleViews()
+
+	a.cfg.NetworkInterface = name
+	engine, err := core.BuildEngine(a.cfg, a.logger)
+	if err != nil {
+		a.logger.Error("failed to build engine for interface", "interface", name, "error", err)
+		return
+	}
+
+	a.engine = engine
+	a.portScanner = discovery.NewPortScanner(100, engine.Iface)
+	a.state.SetCurrentInterface(name)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	a.engineCancel = cancel
+
+	a.engine.Start(context.Background())
+	go a.handleEngineEvents(ctx, engine)
+}
+

--- a/internal/ui/components/device_table.go
+++ b/internal/ui/components/device_table.go
@@ -63,6 +63,12 @@ func (dt *DeviceTable) handleNormalKey(ev *tcell.EventKey) *tcell.EventKey {
 			return nil
 		}
 		return ev
+	case ev.Key() == tcell.KeyCtrlD:
+		dt.moveSelection(10)
+		return nil
+	case ev.Key() == tcell.KeyCtrlU:
+		dt.moveSelection(-10)
+		return nil
 	case ev.Rune() == '/':
 		dt.searching = true
 		dt.searchInput = ""
@@ -201,6 +207,18 @@ func (dt *DeviceTable) SelectLast() {
 	if rows > 1 {
 		dt.Select(rows-1, 0)
 	}
+}
+
+func (dt *DeviceTable) moveSelection(delta int) {
+	row, col := dt.GetSelection()
+	target := row + delta
+	if target < 1 {
+		target = 1
+	}
+	if lastRow := dt.GetRowCount() - 1; target > lastRow {
+		target = lastRow
+	}
+	dt.Select(target, col)
 }
 
 type tableRow struct {

--- a/internal/ui/components/interface_picker.go
+++ b/internal/ui/components/interface_picker.go
@@ -164,7 +164,3 @@ func interfaceDescription(name string) string {
 	}
 	return ""
 }
-
-
-
-

--- a/internal/ui/components/interface_picker.go
+++ b/internal/ui/components/interface_picker.go
@@ -1,0 +1,166 @@
+package components
+
+import (
+	"fmt"
+	"net"
+	"slices"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/ramonvermeulen/whosthere/internal/core/state"
+	"github.com/ramonvermeulen/whosthere/internal/ui/events"
+	"github.com/ramonvermeulen/whosthere/internal/ui/theme"
+	"github.com/rivo/tview"
+)
+
+var _ UIComponent = &InterfacePicker{}
+
+type InterfacePicker struct {
+	*tview.List
+	interfaces       []string
+	currentInterface string
+	initialized      bool
+	emit             func(events.Event)
+}
+
+func NewInterfacePicker(emit func(events.Event)) *InterfacePicker {
+	list := tview.NewList()
+	list.ShowSecondaryText(true)
+
+	ip := &InterfacePicker{
+		List: list,
+		emit: emit,
+	}
+
+	theme.RegisterPrimitive(list)
+	return ip
+}
+
+func (ip *InterfacePicker) setupInputHandling() {
+	ip.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		switch {
+		case event.Rune() == 'j' || event.Key() == tcell.KeyDown:
+			nextIdx := ip.GetCurrentItem() + 1
+			if nextIdx < len(ip.interfaces) {
+				ip.SetCurrentItem(nextIdx)
+			}
+			return nil
+		case event.Rune() == 'k' || event.Key() == tcell.KeyUp:
+			prevIdx := ip.GetCurrentItem() - 1
+			if prevIdx >= 0 {
+				ip.SetCurrentItem(prevIdx)
+			}
+			return nil
+		case event.Key() == tcell.KeyEnter:
+			currentIdx := ip.GetCurrentItem()
+			if currentIdx >= 0 && currentIdx < len(ip.interfaces) {
+				selected := ip.interfaces[currentIdx]
+				if selected != ip.currentInterface {
+					ip.emit(events.InterfaceSelected{Name: selected})
+				}
+				ip.emit(events.HideView{})
+			}
+			return nil
+		case event.Key() == tcell.KeyEsc || event.Rune() == 'q':
+			ip.emit(events.HideView{})
+			return nil
+		}
+		return event
+	})
+}
+
+func (ip *InterfacePicker) Render(s state.ReadOnly) {
+	newInterfaces := listUsableInterfaces()
+	newCurrentInterface := s.CurrentInterface()
+
+	interfacesChanged := !slices.Equal(ip.interfaces, newInterfaces)
+	activeChanged := ip.currentInterface != newCurrentInterface
+
+	if ip.initialized && !interfacesChanged && !activeChanged {
+		return
+	}
+
+	savedIdx := ip.GetCurrentItem()
+
+	ip.Clear()
+	ip.interfaces = newInterfaces
+	ip.currentInterface = newCurrentInterface
+
+	ip.SetBorder(true).
+		SetTitle(fmt.Sprintf(" Network Interfaces (%d) ", len(ip.interfaces))).
+		SetTitleAlign(tview.AlignCenter).
+		SetTitleColor(tview.Styles.TitleColor).
+		SetBorderColor(tview.Styles.BorderColor).
+		SetBackgroundColor(tview.Styles.PrimitiveBackgroundColor)
+
+	var activeIndex int
+	for i, name := range ip.interfaces {
+		displayName := name
+		secondary := interfaceDescription(name)
+		if name == ip.currentInterface {
+			displayName = "✓ " + displayName
+			activeIndex = i
+		}
+		ip.AddItem(displayName, secondary, 0, nil)
+	}
+
+	if ip.initialized && !activeChanged && savedIdx >= 0 && savedIdx < len(ip.interfaces) {
+		ip.SetCurrentItem(savedIdx)
+	} else {
+		ip.SetCurrentItem(activeIndex)
+	}
+
+	ip.initialized = true
+	ip.setupInputHandling()
+}
+
+func listUsableInterfaces() []string {
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return nil
+	}
+	var result []string
+	for _, iface := range ifaces {
+		if iface.Flags&net.FlagLoopback != 0 {
+			continue
+		}
+		if iface.Flags&net.FlagUp == 0 {
+			continue
+		}
+		addrs, err := iface.Addrs()
+		if err != nil || len(addrs) == 0 {
+			continue
+		}
+		hasIPv4 := false
+		for _, addr := range addrs {
+			if ipnet, ok := addr.(*net.IPNet); ok && ipnet.IP.To4() != nil {
+				hasIPv4 = true
+				break
+			}
+		}
+		if hasIPv4 {
+			result = append(result, iface.Name)
+		}
+	}
+	return result
+}
+
+func interfaceDescription(name string) string {
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return ""
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return ""
+	}
+	for _, addr := range addrs {
+		if ipnet, ok := addr.(*net.IPNet); ok && ipnet.IP.To4() != nil {
+			return ipnet.IP.String() + " " + ipnet.String()
+		}
+	}
+	return ""
+}
+
+
+
+

--- a/internal/ui/components/interface_picker.go
+++ b/internal/ui/components/interface_picker.go
@@ -24,7 +24,7 @@ type InterfacePicker struct {
 
 func NewInterfacePicker(emit func(events.Event)) *InterfacePicker {
 	list := tview.NewList()
-	list.ShowSecondaryText(true)
+	list.ShowSecondaryText(false)
 
 	ip := &InterfacePicker{
 		List: list,
@@ -95,12 +95,14 @@ func (ip *InterfacePicker) Render(s state.ReadOnly) {
 	var activeIndex int
 	for i, name := range ip.interfaces {
 		displayName := name
-		secondary := interfaceDescription(name)
+		if desc := interfaceDescription(name); desc != "" {
+			displayName += " (" + desc + ")"
+		}
 		if name == ip.currentInterface {
 			displayName = "✓ " + displayName
 			activeIndex = i
 		}
-		ip.AddItem(displayName, secondary, 0, nil)
+		ip.AddItem(displayName, "", 0, nil)
 	}
 
 	if ip.initialized && !activeChanged && savedIdx >= 0 && savedIdx < len(ip.interfaces) {
@@ -155,7 +157,9 @@ func interfaceDescription(name string) string {
 	}
 	for _, addr := range addrs {
 		if ipnet, ok := addr.(*net.IPNet); ok && ipnet.IP.To4() != nil {
-			return ipnet.IP.String() + " " + ipnet.String()
+			network := ipnet.IP.Mask(ipnet.Mask)
+			ones, _ := ipnet.Mask.Size()
+			return fmt.Sprintf("%s - %s/%d", ipnet.IP.String(), network.String(), ones)
 		}
 	}
 	return ""

--- a/internal/ui/events/events.go
+++ b/internal/ui/events/events.go
@@ -67,3 +67,9 @@ type CopyIP struct {
 type CopyMac struct {
 	MAC string
 }
+
+// InterfaceSelected is emitted when a network interface is selected.
+type InterfaceSelected struct {
+	Name string
+}
+

--- a/internal/ui/routes/navigation.go
+++ b/internal/ui/routes/navigation.go
@@ -1,9 +1,10 @@
 package routes
 
 const (
-	RouteDashboard   = "dashboard"
-	RouteSplash      = "splash"
-	RouteDetail      = "detail"
-	RouteThemePicker = "theme-picker"
-	RoutePortScan    = "port-scan"
+	RouteDashboard       = "dashboard"
+	RouteSplash          = "splash"
+	RouteDetail          = "detail"
+	RouteThemePicker     = "theme-picker"
+	RoutePortScan        = "port-scan"
+	RouteInterfacePicker = "interface-picker"
 )

--- a/internal/ui/views/dashboard.go
+++ b/internal/ui/views/dashboard.go
@@ -38,6 +38,7 @@ func NewDashboardView(emit func(events.Event), queue func(f func())) *DashboardV
 		"j/k: up/down" + components.Divider +
 			"Enter: details" + components.Divider +
 			"y: copy" + components.Divider +
+			"Ctrl+I: interface" + components.Divider +
 			"Ctrl+T: theme" + components.Divider +
 			"q: quit",
 	)

--- a/internal/ui/views/detail.go
+++ b/internal/ui/views/detail.go
@@ -145,6 +145,9 @@ func (d *DetailView) Render(s state.ReadOnly) {
 	writeLine("Display Name", device.DisplayName())
 	writeLine("MAC", device.MAC())
 	writeLine("Manufacturer", device.Manufacturer())
+	if iface := device.InterfaceName(); iface != "" {
+		writeLine("Interface", iface)
+	}
 	writeLine("First Seen", formatTime(device.FirstSeen()))
 	writeLine("Last Seen", formatTime(device.LastSeen()))
 	_, _ = fmt.Fprintln(d.info)

--- a/internal/ui/views/interface_modal.go
+++ b/internal/ui/views/interface_modal.go
@@ -1,0 +1,62 @@
+package views
+
+import (
+	"github.com/ramonvermeulen/whosthere/internal/core/state"
+	"github.com/ramonvermeulen/whosthere/internal/ui/components"
+	"github.com/ramonvermeulen/whosthere/internal/ui/events"
+	"github.com/ramonvermeulen/whosthere/internal/ui/theme"
+	"github.com/rivo/tview"
+)
+
+var _ View = &InterfaceModalView{}
+
+type InterfaceModalView struct {
+	*tview.Flex
+	picker *components.InterfacePicker
+	footer *tview.TextView
+
+	emit func(events.Event)
+}
+
+func NewInterfaceModalView(emit func(events.Event)) *InterfaceModalView {
+	picker := components.NewInterfacePicker(emit)
+	footer := tview.NewTextView()
+	footer.SetDynamicColors(true).
+		SetTextAlign(tview.AlignCenter).
+		SetText("j/k: navigate" + components.Divider + "Enter: select" + components.Divider + "Esc: cancel")
+	footer.SetTextColor(tview.Styles.SecondaryTextColor)
+	footer.SetBackgroundColor(tview.Styles.PrimitiveBackgroundColor)
+
+	content := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(picker, 0, 1, true).
+		AddItem(footer, 1, 0, false)
+
+	modalWidth := len(footer.GetText(false)) + 10
+
+	root := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(nil, 0, 1, false).
+		AddItem(tview.NewFlex().SetDirection(tview.FlexColumn).
+			AddItem(nil, 0, 1, false).
+			AddItem(content, modalWidth, 0, true).
+			AddItem(nil, 0, 1, false), 0, 1, true).
+		AddItem(nil, 0, 1, false)
+
+	v := &InterfaceModalView{
+		Flex:   root,
+		picker: picker,
+		footer: footer,
+		emit:   emit,
+	}
+
+	theme.RegisterPrimitive(content)
+	theme.RegisterPrimitive(footer)
+
+	return v
+}
+
+func (v *InterfaceModalView) FocusTarget() tview.Primitive { return v.picker }
+
+func (v *InterfaceModalView) Render(s state.ReadOnly) {
+	v.picker.Render(s)
+}
+

--- a/pkg/discovery/device.go
+++ b/pkg/discovery/device.go
@@ -28,17 +28,18 @@ import (
 // Devices are uniquely identified by their IP address. When the same IP is seen
 // by multiple scanners, their data is merged using the Merge method.
 type Device struct {
-	mu           sync.RWMutex
-	ip           net.IP
-	mac          string
-	displayName  string
-	manufacturer string
-	sources      map[string]struct{}
-	firstSeen    time.Time
-	lastSeen     time.Time
-	extraData    map[string]string
-	openPorts    map[string][]int
-	lastPortScan time.Time
+	mu            sync.RWMutex
+	ip            net.IP
+	mac           string
+	displayName   string
+	manufacturer  string
+	interfaceName string
+	sources       map[string]struct{}
+	firstSeen     time.Time
+	lastSeen      time.Time
+	extraData     map[string]string
+	openPorts     map[string][]int
+	lastPortScan  time.Time
 }
 
 // NewDevice creates a Device with the given IP address and initializes all maps.
@@ -114,6 +115,9 @@ func (d *Device) Merge(other *Device) {
 	if d.manufacturer == "" && other.manufacturer != "" {
 		d.manufacturer = other.manufacturer
 	}
+	if d.interfaceName == "" && other.interfaceName != "" {
+		d.interfaceName = other.interfaceName
+	}
 	if d.sources == nil {
 		d.sources = make(map[string]struct{})
 	}
@@ -188,6 +192,20 @@ func (d *Device) Manufacturer() string {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return d.manufacturer
+}
+
+// InterfaceName returns the network interface this device was discovered on.
+func (d *Device) InterfaceName() string {
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	return d.interfaceName
+}
+
+// SetInterfaceName sets the network interface this device was discovered on.
+func (d *Device) SetInterfaceName(name string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.interfaceName = name
 }
 
 // Sources returns a copy of the device's sources map.
@@ -353,16 +371,17 @@ func (d *Device) Copy() *Device {
 	defer d.mu.RUnlock()
 
 	newD := &Device{
-		ip:           append(net.IP(nil), d.ip...),
-		mac:          d.mac,
-		displayName:  d.displayName,
-		manufacturer: d.manufacturer,
-		sources:      make(map[string]struct{}),
-		firstSeen:    d.firstSeen,
-		lastSeen:     d.lastSeen,
-		extraData:    make(map[string]string),
-		openPorts:    make(map[string][]int),
-		lastPortScan: d.lastPortScan,
+		ip:            append(net.IP(nil), d.ip...),
+		mac:           d.mac,
+		displayName:   d.displayName,
+		manufacturer:  d.manufacturer,
+		interfaceName: d.interfaceName,
+		sources:       make(map[string]struct{}),
+		firstSeen:     d.firstSeen,
+		lastSeen:      d.lastSeen,
+		extraData:     make(map[string]string),
+		openPorts:     make(map[string][]int),
+		lastPortScan:  d.lastPortScan,
 	}
 
 	for k := range d.sources {
@@ -385,14 +404,15 @@ func (d *Device) MarshalJSON() ([]byte, error) {
 	defer d.mu.RUnlock()
 
 	type temp struct {
-		IP           string            `json:"ip"`
-		MAC          string            `json:"mac"`
-		DisplayName  string            `json:"displayName"`
-		Manufacturer string            `json:"manufacturer"`
-		Sources      []string          `json:"sources"`
-		FirstSeen    time.Time         `json:"firstSeen"`
-		LastSeen     time.Time         `json:"lastSeen"`
-		ExtraData    map[string]string `json:"extraData"`
+		IP            string            `json:"ip"`
+		MAC           string            `json:"mac"`
+		DisplayName   string            `json:"displayName"`
+		Manufacturer  string            `json:"manufacturer"`
+		InterfaceName string            `json:"interfaceName,omitempty"`
+		Sources       []string          `json:"sources"`
+		FirstSeen     time.Time         `json:"firstSeen"`
+		LastSeen      time.Time         `json:"lastSeen"`
+		ExtraData     map[string]string `json:"extraData"`
 	}
 
 	ipStr := ""
@@ -401,14 +421,15 @@ func (d *Device) MarshalJSON() ([]byte, error) {
 	}
 
 	t := temp{
-		IP:           ipStr,
-		MAC:          d.mac,
-		DisplayName:  d.displayName,
-		Manufacturer: d.manufacturer,
-		Sources:      make([]string, 0, len(d.sources)),
-		FirstSeen:    d.firstSeen,
-		LastSeen:     d.lastSeen,
-		ExtraData:    make(map[string]string, len(d.extraData)),
+		IP:            ipStr,
+		MAC:           d.mac,
+		DisplayName:   d.displayName,
+		Manufacturer:  d.manufacturer,
+		InterfaceName: d.interfaceName,
+		Sources:       make([]string, 0, len(d.sources)),
+		FirstSeen:     d.firstSeen,
+		LastSeen:      d.lastSeen,
+		ExtraData:     make(map[string]string, len(d.extraData)),
 	}
 
 	for source := range d.sources {

--- a/pkg/discovery/scanners/arp/arp.go
+++ b/pkg/discovery/scanners/arp/arp.go
@@ -22,8 +22,9 @@ var _ discovery.Scanner = (*Scanner)(nil)
 type Scanner struct {
 	iface *discovery.InterfaceInfo
 
-	logger       discovery.Logger
-	pollInterval time.Duration
+	logger        discovery.Logger
+	pollInterval  time.Duration
+	allInterfaces bool
 }
 
 // New creates an ARP scanner for the specified network interface.
@@ -109,15 +110,10 @@ func (s *Scanner) emitARPEntries(ctx context.Context, out chan<- *discovery.Devi
 			continue
 		}
 
-		if entry.InterfaceName != s.iface.Interface.Name {
+		if !s.allInterfaces && entry.InterfaceName != s.iface.Interface.Name {
 			continue
 		}
 
-		// Filter non-device addresses:
-		// - skip multicast MACs (I/G bit set)
-		// - skip broadcast MAC (FF:FF:FF:FF:FF:FF)
-		// - skip IPv4 broadcast address for our subnet
-		// - skip IPv4 multicast ranges (224.0.0.0/4)
 		if isMulticastMAC(entry.MAC) || isBroadcastMAC(entry.MAC) || isMulticastIPv4(entry.IP) || isBroadcastIPv4(entry.IP, subnet) {
 			continue
 		}
@@ -125,6 +121,7 @@ func (s *Scanner) emitARPEntries(ctx context.Context, out chan<- *discovery.Devi
 		dd := discovery.NewDevice(entry.IP)
 		dd.SetMAC(entry.MAC.String())
 		dd.AddSource(s.Name())
+		dd.SetInterfaceName(entry.InterfaceName)
 
 		if entry.Age > 0 {
 			dd.SetLastSeen(now.Add(-entry.Age))

--- a/pkg/discovery/scanners/arp/arp_options.go
+++ b/pkg/discovery/scanners/arp/arp_options.go
@@ -35,3 +35,14 @@ func WithPollInterval(interval time.Duration) Option {
 		return nil
 	}
 }
+
+// WithAllInterfaces disables interface filtering on the ARP cache.
+// When enabled, the scanner reports devices from all network interfaces
+// instead of only the configured one.
+func WithAllInterfaces(all bool) Option {
+	return func(s *Scanner) error {
+		s.allInterfaces = all
+		return nil
+	}
+}
+

--- a/pkg/discovery/sweeper/sweeper.go
+++ b/pkg/discovery/sweeper/sweeper.go
@@ -139,6 +139,7 @@ func (s *Sweeper) triggerSubnetSweep(ctx context.Context, ips []net.IP) {
 
 	for _, ip := range ips {
 		s.logger.Log(ctx, slog.LevelDebug, "Triggering ARP for IP", "ip", ip.String())
+		s.logger.Log(ctx, slog.LevelDebug, "Triggering ARP for IP", "ip", ip.String())
 		select {
 		case <-ctx.Done():
 			s.logger.Log(ctx, slog.LevelWarn, "ARP sweep interrupted by context cancellation, this can indicate you have a short scan duration configured", "triggered", triggered, "total", total, "remaining", total-triggered)

--- a/pkg/discovery/sweeper/sweeper.go
+++ b/pkg/discovery/sweeper/sweeper.go
@@ -139,7 +139,6 @@ func (s *Sweeper) triggerSubnetSweep(ctx context.Context, ips []net.IP) {
 
 	for _, ip := range ips {
 		s.logger.Log(ctx, slog.LevelDebug, "Triggering ARP for IP", "ip", ip.String())
-		s.logger.Log(ctx, slog.LevelDebug, "Triggering ARP for IP", "ip", ip.String())
 		select {
 		case <-ctx.Done():
 			s.logger.Log(ctx, slog.LevelWarn, "ARP sweep interrupted by context cancellation, this can indicate you have a short scan duration configured", "triggered", triggered, "total", total, "remaining", total-triggered)


### PR DESCRIPTION
Closes https://github.com/ramonvermeulen/whosthere/issues/58

With this PR it makes it possible to switch the network interface at runtime (doesn't require an application restart anymore). Also an `all_interfaces` configuration option is added (default `false`) which allows results to be mixed. For example your local ARP cache provides entries for multiple network interfaces. When this setting is set to `true`, the arp cache results will not be filtered on only the currently selected network interface, but rather return results for all interfaces. I added a warning with this setting, because if you have overlapping subnets over different interfaces on the same system, theoretically "unique" devices can get merged into a single `Device` struct entry.

**Example:**

<img width="524" height="371" alt="image" src="https://github.com/user-attachments/assets/a9914bb7-cf2d-405f-835d-a7d6e15e3781" />

