### PR TITLE
feat(tui): persist and edit aliases for device display name per unique mac address in a bbolt storage layer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
+	go.etcd.io/bbolt v1.4.3 // indirect
 	golang.org/x/mod v0.35.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/text v0.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,8 @@ github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3A
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+go.etcd.io/bbolt v1.4.3 h1:dEadXpI6G79deX5prL3QRNP6JB8UxVkqo4UPnHaNXJo=
+go.etcd.io/bbolt v1.4.3/go.mod h1:tKQlpPaYCVFctUIgFKFnAlvbmB3tpy1vkTnDWohtc0E=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/internal/core/devicemeta/bbolt_store.go
+++ b/internal/core/devicemeta/bbolt_store.go
@@ -1,7 +1,6 @@
 package devicemeta
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,16 +10,12 @@ import (
 	"time"
 
 	bolt "go.etcd.io/bbolt"
-	bolterrors "go.etcd.io/bbolt/errors"
 )
 
 var ErrInvalidMAC = errors.New("invalid MAC address")
 
 var (
-	metaBucket         = []byte("meta")
-	devicesBucket      = []byte("devices")
-	schemaVersionKey   = []byte("schema_version")
-	currentSchemaValue = []byte("1")
+	deviceMetadataBucket = []byte("device_metadata")
 )
 
 type boltStore struct {
@@ -49,21 +44,8 @@ func Open(path string) (Store, error) {
 
 func (s *boltStore) init() error {
 	return s.db.Update(func(tx *bolt.Tx) error {
-		meta, err := tx.CreateBucketIfNotExists(metaBucket)
-		if err != nil {
-			return fmt.Errorf("create meta bucket: %w", err)
-		}
-
-		if _, err := tx.CreateBucketIfNotExists(devicesBucket); err != nil {
-			return fmt.Errorf("create devices bucket: %w", err)
-		}
-
-		version := meta.Get(schemaVersionKey)
-		if len(version) == 0 {
-			return meta.Put(schemaVersionKey, currentSchemaValue)
-		}
-		if !bytes.Equal(version, currentSchemaValue) {
-			return fmt.Errorf("unsupported metadata schema version %q", version)
+		if _, err := tx.CreateBucketIfNotExists(deviceMetadataBucket); err != nil {
+			return fmt.Errorf("create device metadata bucket: %w", err)
 		}
 
 		return nil
@@ -71,10 +53,11 @@ func (s *boltStore) init() error {
 }
 
 func (s *boltStore) Get(mac string) (Record, bool, error) {
-	normalized, ok := NormalizeMAC(mac)
-	if !ok {
+	normalizedMAC, isValidMAC := NormalizeMAC(mac)
+	if !isValidMAC {
 		return Record{}, false, ErrInvalidMAC
 	}
+	macKey := []byte(normalizedMAC)
 
 	var (
 		record Record
@@ -82,19 +65,19 @@ func (s *boltStore) Get(mac string) (Record, bool, error) {
 	)
 
 	err := s.db.View(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(devicesBucket)
-		if bucket == nil {
-			return nil
+		deviceMetadata := tx.Bucket(deviceMetadataBucket)
+		if deviceMetadata == nil {
+			return errors.New("device metadata bucket not initialized")
 		}
 
-		raw := bucket.Get([]byte(normalized))
-		if len(raw) == 0 {
+		rawRecord := deviceMetadata.Get(macKey)
+		if len(rawRecord) == 0 {
 			return nil
 		}
 
 		found = true
-		if err := json.Unmarshal(raw, &record); err != nil {
-			return fmt.Errorf("decode record for %s: %w", normalized, err)
+		if err := json.Unmarshal(rawRecord, &record); err != nil {
+			return fmt.Errorf("decode record for %s: %w", normalizedMAC, err)
 		}
 
 		return nil
@@ -107,20 +90,21 @@ func (s *boltStore) Get(mac string) (Record, bool, error) {
 }
 
 func (s *boltStore) SetAlias(mac, alias string) error {
-	normalized, ok := NormalizeMAC(mac)
-	if !ok {
+	normalizedMAC, isValidMAC := NormalizeMAC(mac)
+	if !isValidMAC {
 		return ErrInvalidMAC
 	}
+	macKey := []byte(normalizedMAC)
 
 	alias = strings.TrimSpace(alias)
 	if alias == "" {
-		return s.ClearAlias(normalized)
+		return s.ClearAlias(normalizedMAC)
 	}
 
 	return s.db.Update(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(devicesBucket)
-		if bucket == nil {
-			return errors.New("devices bucket not initialized")
+		deviceMetadata := tx.Bucket(deviceMetadataBucket)
+		if deviceMetadata == nil {
+			return errors.New("device metadata bucket not initialized")
 		}
 
 		record := Record{
@@ -130,58 +114,71 @@ func (s *boltStore) SetAlias(mac, alias string) error {
 
 		raw, err := json.Marshal(record)
 		if err != nil {
-			return fmt.Errorf("encode record for %s: %w", normalized, err)
+			return fmt.Errorf("encode record for %s: %w", normalizedMAC, err)
 		}
 
-		return bucket.Put([]byte(normalized), raw)
+		return deviceMetadata.Put(macKey, raw)
 	})
 }
 
 func (s *boltStore) ClearAlias(mac string) error {
-	normalized, ok := NormalizeMAC(mac)
-	if !ok {
+	normalizedMAC, isValidMAC := NormalizeMAC(mac)
+	if !isValidMAC {
 		return ErrInvalidMAC
 	}
+	macKey := []byte(normalizedMAC)
 
 	return s.db.Update(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(devicesBucket)
-		if bucket == nil {
-			return errors.New("devices bucket not initialized")
+		deviceMetadata := tx.Bucket(deviceMetadataBucket)
+		if deviceMetadata == nil {
+			return errors.New("device metadata bucket not initialized")
 		}
 
-		raw := bucket.Get([]byte(normalized))
-		if len(raw) == 0 {
+		rawRecord := deviceMetadata.Get(macKey)
+		if len(rawRecord) == 0 {
 			return nil
 		}
 
 		var record Record
-		if err := json.Unmarshal(raw, &record); err != nil {
-			return fmt.Errorf("decode record for %s: %w", normalized, err)
+		if err := json.Unmarshal(rawRecord, &record); err != nil {
+			return fmt.Errorf("decode record for %s: %w", normalizedMAC, err)
 		}
 
 		record.Alias = ""
 		record.UpdatedAt = time.Now()
 		if record.empty() {
-			return bucket.Delete([]byte(normalized))
+			return deviceMetadata.Delete(macKey)
 		}
 
-		updated, err := json.Marshal(record)
+		updatedRecord, err := json.Marshal(record)
 		if err != nil {
-			return fmt.Errorf("encode record for %s: %w", normalized, err)
+			return fmt.Errorf("encode record for %s: %w", normalizedMAC, err)
 		}
 
-		return bucket.Put([]byte(normalized), updated)
+		return deviceMetadata.Put(macKey, updatedRecord)
 	})
 }
 
 func (s *boltStore) ResetAliases() error {
 	return s.db.Update(func(tx *bolt.Tx) error {
-		if err := tx.DeleteBucket(devicesBucket); err != nil && !errors.Is(err, bolterrors.ErrBucketNotFound) {
-			return fmt.Errorf("delete devices bucket: %w", err)
+		deviceMetadata := tx.Bucket(deviceMetadataBucket)
+		if deviceMetadata == nil {
+			return errors.New("device metadata bucket not initialized")
 		}
 
-		if _, err := tx.CreateBucketIfNotExists(devicesBucket); err != nil {
-			return fmt.Errorf("recreate devices bucket: %w", err)
+		var macKeys [][]byte
+		if err := deviceMetadata.ForEach(func(macKey, _ []byte) error {
+			macKeyCopy := append([]byte(nil), macKey...)
+			macKeys = append(macKeys, macKeyCopy)
+			return nil
+		}); err != nil {
+			return fmt.Errorf("list device metadata keys: %w", err)
+		}
+
+		for _, macKey := range macKeys {
+			if err := deviceMetadata.Delete(macKey); err != nil {
+				return fmt.Errorf("delete alias for %s: %w", string(macKey), err)
+			}
 		}
 
 		return nil

--- a/internal/core/devicemeta/bbolt_store.go
+++ b/internal/core/devicemeta/bbolt_store.go
@@ -1,0 +1,195 @@
+package devicemeta
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	bolt "go.etcd.io/bbolt"
+)
+
+var ErrInvalidMAC = errors.New("invalid MAC address")
+
+var (
+	metaBucket         = []byte("meta")
+	devicesBucket      = []byte("devices")
+	schemaVersionKey   = []byte("schema_version")
+	currentSchemaValue = []byte("1")
+)
+
+type boltStore struct {
+	db *bolt.DB
+}
+
+// Open opens or creates a bbolt-backed device metadata store.
+func Open(path string) (Store, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create metadata dir: %w", err)
+	}
+
+	db, err := bolt.Open(path, 0o600, &bolt.Options{Timeout: 1 * time.Second})
+	if err != nil {
+		return nil, fmt.Errorf("open metadata store: %w", err)
+	}
+
+	store := &boltStore{db: db}
+	if err := store.init(); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+
+	return store, nil
+}
+
+func (s *boltStore) init() error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		meta, err := tx.CreateBucketIfNotExists(metaBucket)
+		if err != nil {
+			return fmt.Errorf("create meta bucket: %w", err)
+		}
+
+		if _, err := tx.CreateBucketIfNotExists(devicesBucket); err != nil {
+			return fmt.Errorf("create devices bucket: %w", err)
+		}
+
+		version := meta.Get(schemaVersionKey)
+		if len(version) == 0 {
+			return meta.Put(schemaVersionKey, currentSchemaValue)
+		}
+		if string(version) != string(currentSchemaValue) {
+			return fmt.Errorf("unsupported metadata schema version %q", version)
+		}
+
+		return nil
+	})
+}
+
+func (s *boltStore) Get(mac string) (Record, bool, error) {
+	normalized, ok := NormalizeMAC(mac)
+	if !ok {
+		return Record{}, false, ErrInvalidMAC
+	}
+
+	var (
+		record Record
+		found  bool
+	)
+
+	err := s.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(devicesBucket)
+		if bucket == nil {
+			return nil
+		}
+
+		raw := bucket.Get([]byte(normalized))
+		if len(raw) == 0 {
+			return nil
+		}
+
+		found = true
+		if err := json.Unmarshal(raw, &record); err != nil {
+			return fmt.Errorf("decode record for %s: %w", normalized, err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return Record{}, false, err
+	}
+
+	return record, found, nil
+}
+
+func (s *boltStore) SetAlias(mac, alias string) error {
+	normalized, ok := NormalizeMAC(mac)
+	if !ok {
+		return ErrInvalidMAC
+	}
+
+	alias = strings.TrimSpace(alias)
+	if alias == "" {
+		return s.ClearAlias(normalized)
+	}
+
+	return s.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(devicesBucket)
+		if bucket == nil {
+			return errors.New("devices bucket not initialized")
+		}
+
+		record := Record{
+			Alias:     alias,
+			UpdatedAt: time.Now(),
+		}
+
+		raw, err := json.Marshal(record)
+		if err != nil {
+			return fmt.Errorf("encode record for %s: %w", normalized, err)
+		}
+
+		return bucket.Put([]byte(normalized), raw)
+	})
+}
+
+func (s *boltStore) ClearAlias(mac string) error {
+	normalized, ok := NormalizeMAC(mac)
+	if !ok {
+		return ErrInvalidMAC
+	}
+
+	return s.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(devicesBucket)
+		if bucket == nil {
+			return errors.New("devices bucket not initialized")
+		}
+
+		raw := bucket.Get([]byte(normalized))
+		if len(raw) == 0 {
+			return nil
+		}
+
+		var record Record
+		if err := json.Unmarshal(raw, &record); err != nil {
+			return fmt.Errorf("decode record for %s: %w", normalized, err)
+		}
+
+		record.Alias = ""
+		record.UpdatedAt = time.Now()
+		if record.empty() {
+			return bucket.Delete([]byte(normalized))
+		}
+
+		updated, err := json.Marshal(record)
+		if err != nil {
+			return fmt.Errorf("encode record for %s: %w", normalized, err)
+		}
+
+		return bucket.Put([]byte(normalized), updated)
+	})
+}
+
+func (s *boltStore) ResetAliases() error {
+	return s.db.Update(func(tx *bolt.Tx) error {
+		if err := tx.DeleteBucket(devicesBucket); err != nil && !errors.Is(err, bolt.ErrBucketNotFound) {
+			return fmt.Errorf("delete devices bucket: %w", err)
+		}
+
+		if _, err := tx.CreateBucketIfNotExists(devicesBucket); err != nil {
+			return fmt.Errorf("recreate devices bucket: %w", err)
+		}
+
+		return nil
+	})
+}
+
+func (s *boltStore) Close() error {
+	if s == nil || s.db == nil {
+		return nil
+	}
+
+	return s.db.Close()
+}

--- a/internal/core/devicemeta/bbolt_store.go
+++ b/internal/core/devicemeta/bbolt_store.go
@@ -1,6 +1,7 @@
 package devicemeta
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	bolt "go.etcd.io/bbolt"
+	bolterrors "go.etcd.io/bbolt/errors"
 )
 
 var ErrInvalidMAC = errors.New("invalid MAC address")
@@ -60,7 +62,7 @@ func (s *boltStore) init() error {
 		if len(version) == 0 {
 			return meta.Put(schemaVersionKey, currentSchemaValue)
 		}
-		if string(version) != string(currentSchemaValue) {
+		if !bytes.Equal(version, currentSchemaValue) {
 			return fmt.Errorf("unsupported metadata schema version %q", version)
 		}
 
@@ -174,7 +176,7 @@ func (s *boltStore) ClearAlias(mac string) error {
 
 func (s *boltStore) ResetAliases() error {
 	return s.db.Update(func(tx *bolt.Tx) error {
-		if err := tx.DeleteBucket(devicesBucket); err != nil && !errors.Is(err, bolt.ErrBucketNotFound) {
+		if err := tx.DeleteBucket(devicesBucket); err != nil && !errors.Is(err, bolterrors.ErrBucketNotFound) {
 			return fmt.Errorf("delete devices bucket: %w", err)
 		}
 

--- a/internal/core/devicemeta/bbolt_store_test.go
+++ b/internal/core/devicemeta/bbolt_store_test.go
@@ -1,0 +1,170 @@
+package devicemeta
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestNormalizeMAC(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+		ok    bool
+	}{
+		{
+			name:  "normalizes uppercase with dashes",
+			input: "AA-BB-CC-DD-EE-FF",
+			want:  "aa:bb:cc:dd:ee:ff",
+			ok:    true,
+		},
+		{
+			name:  "trims surrounding whitespace",
+			input: "  aa:bb:cc:dd:ee:ff  ",
+			want:  "aa:bb:cc:dd:ee:ff",
+			ok:    true,
+		},
+		{
+			name:  "rejects invalid MAC",
+			input: "not-a-mac",
+			want:  "",
+			ok:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := NormalizeMAC(tt.input)
+			if ok != tt.ok {
+				t.Fatalf("NormalizeMAC(%q) ok = %v, want %v", tt.input, ok, tt.ok)
+			}
+			if got != tt.want {
+				t.Fatalf("NormalizeMAC(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBoltStore_SetGetClearAlias(t *testing.T) {
+	t.Parallel()
+
+	store, err := Open(filepath.Join(t.TempDir(), "devices.db"))
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	const mac = "AA:BB:CC:DD:EE:FF"
+
+	record, found, err := store.Get(mac)
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if found {
+		t.Fatalf("expected alias record to be absent, got %+v", record)
+	}
+
+	if err := store.SetAlias(mac, " Living Room Speaker "); err != nil {
+		t.Fatalf("SetAlias() error = %v", err)
+	}
+
+	record, found, err = store.Get(mac)
+	if err != nil {
+		t.Fatalf("Get() after SetAlias error = %v", err)
+	}
+	if !found {
+		t.Fatal("expected alias record to exist")
+	}
+	if record.Alias != "Living Room Speaker" {
+		t.Fatalf("record.Alias = %q, want %q", record.Alias, "Living Room Speaker")
+	}
+
+	if err := store.ClearAlias(mac); err != nil {
+		t.Fatalf("ClearAlias() error = %v", err)
+	}
+
+	record, found, err = store.Get(mac)
+	if err != nil {
+		t.Fatalf("Get() after ClearAlias error = %v", err)
+	}
+	if found {
+		t.Fatalf("expected alias record to be removed, got %+v", record)
+	}
+}
+
+func TestBoltStore_PersistsAcrossReopen(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "devices.db")
+
+	store, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+
+	if err := store.SetAlias("aa:bb:cc:dd:ee:ff", "Router"); err != nil {
+		t.Fatalf("SetAlias() error = %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	reopened, err := Open(path)
+	if err != nil {
+		t.Fatalf("Open() reopen error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = reopened.Close()
+	})
+
+	record, found, err := reopened.Get("AA-BB-CC-DD-EE-FF")
+	if err != nil {
+		t.Fatalf("Get() after reopen error = %v", err)
+	}
+	if !found {
+		t.Fatal("expected alias record after reopen")
+	}
+	if record.Alias != "Router" {
+		t.Fatalf("record.Alias = %q, want %q", record.Alias, "Router")
+	}
+}
+
+func TestBoltStore_ResetAliases(t *testing.T) {
+	t.Parallel()
+
+	store, err := Open(filepath.Join(t.TempDir(), "devices.db"))
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		_ = store.Close()
+	})
+
+	if err := store.SetAlias("aa:bb:cc:dd:ee:ff", "Router"); err != nil {
+		t.Fatalf("SetAlias(first) error = %v", err)
+	}
+	if err := store.SetAlias("aa:bb:cc:dd:ee:11", "Printer"); err != nil {
+		t.Fatalf("SetAlias(second) error = %v", err)
+	}
+
+	if err := store.ResetAliases(); err != nil {
+		t.Fatalf("ResetAliases() error = %v", err)
+	}
+
+	tests := []string{"aa:bb:cc:dd:ee:ff", "aa:bb:cc:dd:ee:11"}
+	for _, mac := range tests {
+		record, found, err := store.Get(mac)
+		if err != nil {
+			t.Fatalf("Get(%q) after reset error = %v", mac, err)
+		}
+		if found {
+			t.Fatalf("expected alias for %s to be removed, got %+v", mac, record)
+		}
+	}
+}

--- a/internal/core/devicemeta/normalize.go
+++ b/internal/core/devicemeta/normalize.go
@@ -1,0 +1,16 @@
+package devicemeta
+
+import (
+	"net"
+	"strings"
+)
+
+// NormalizeMAC returns a canonical MAC address in lowercase colon-separated form.
+func NormalizeMAC(mac string) (string, bool) {
+	parsed, err := net.ParseMAC(strings.TrimSpace(mac))
+	if err != nil {
+		return "", false
+	}
+
+	return parsed.String(), true
+}

--- a/internal/core/devicemeta/record.go
+++ b/internal/core/devicemeta/record.go
@@ -1,0 +1,13 @@
+package devicemeta
+
+import "time"
+
+// Record stores local metadata for a device keyed by MAC address.
+type Record struct {
+	Alias     string    `json:"alias,omitempty"`
+	UpdatedAt time.Time `json:"updated_at,omitempty"`
+}
+
+func (r Record) empty() bool {
+	return r.Alias == ""
+}

--- a/internal/core/devicemeta/store.go
+++ b/internal/core/devicemeta/store.go
@@ -1,0 +1,29 @@
+package devicemeta
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/ramonvermeulen/whosthere/internal/core/paths"
+)
+
+const defaultDBFileName = "devices.db"
+
+// Store provides persistent local device metadata keyed by normalized MAC address.
+type Store interface {
+	Get(mac string) (Record, bool, error)
+	SetAlias(mac, alias string) error
+	ClearAlias(mac string) error
+	ResetAliases() error
+	Close() error
+}
+
+// OpenDefault opens the metadata store in the application's state directory.
+func OpenDefault() (Store, error) {
+	dir, err := paths.StateDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolve state dir: %w", err)
+	}
+
+	return Open(filepath.Join(dir, defaultDBFileName))
+}

--- a/internal/core/state/device_entry.go
+++ b/internal/core/state/device_entry.go
@@ -1,0 +1,102 @@
+package state
+
+import (
+	"strings"
+
+	"github.com/ramonvermeulen/whosthere/pkg/discovery"
+)
+
+type deviceEntry struct {
+	device              *discovery.Device
+	normalizedMAC       string
+	alias               string
+	aliasMetadataLoaded bool
+}
+
+func newDeviceEntry(device *discovery.Device) *deviceEntry {
+	deviceCopy := device.Copy()
+	normalizedMAC, _ := normalizedDeviceMAC(deviceCopy)
+
+	return &deviceEntry{
+		device:        deviceCopy,
+		normalizedMAC: normalizedMAC,
+	}
+}
+
+func (e *deviceEntry) Merge(device *discovery.Device) {
+	if e == nil || e.device == nil || device == nil {
+		return
+	}
+
+	e.device.Merge(device)
+	if e.normalizedMAC == "" {
+		e.normalizedMAC, _ = normalizedDeviceMAC(e.device)
+	}
+}
+
+func (e *deviceEntry) Device() *discovery.Device {
+	if e == nil {
+		return nil
+	}
+
+	return e.device
+}
+
+func (e *deviceEntry) HasMAC(normalizedMAC string) bool {
+	return e != nil && e.normalizedMAC != "" && e.normalizedMAC == normalizedMAC
+}
+
+func (e *deviceEntry) Alias() string {
+	if e == nil {
+		return ""
+	}
+
+	return e.alias
+}
+
+func (e *deviceEntry) SetAlias(alias string) {
+	if e == nil {
+		return
+	}
+
+	e.aliasMetadataLoaded = true
+	e.alias = strings.TrimSpace(alias)
+}
+
+func (e *deviceEntry) ClearAlias() {
+	e.SetAlias("")
+}
+
+func (e *deviceEntry) ResetAlias() {
+	if e == nil {
+		return
+	}
+
+	e.alias = ""
+	e.aliasMetadataLoaded = false
+}
+
+func (e *deviceEntry) AliasMetadataLoaded() bool {
+	return e != nil && e.aliasMetadataLoaded
+}
+
+func (e *deviceEntry) PreferredName() string {
+	if e == nil || e.device == nil {
+		return ""
+	}
+
+	if e.alias != "" {
+		return e.alias
+	}
+	if discoveredName := e.device.DisplayName(); discoveredName != "" {
+		return discoveredName
+	}
+	if manufacturer := e.device.Manufacturer(); manufacturer != "" {
+		return manufacturer
+	}
+	if ip := e.device.IP(); ip != nil {
+		return ip.String()
+	}
+
+	return ""
+}

--- a/internal/core/state/mac.go
+++ b/internal/core/state/mac.go
@@ -1,0 +1,14 @@
+package state
+
+import (
+	"github.com/ramonvermeulen/whosthere/internal/core/devicemeta"
+	"github.com/ramonvermeulen/whosthere/pkg/discovery"
+)
+
+func normalizeDeviceMAC(d *discovery.Device) (string, bool) {
+	if d == nil {
+		return "", false
+	}
+
+	return devicemeta.NormalizeMAC(d.MAC())
+}

--- a/internal/core/state/mac.go
+++ b/internal/core/state/mac.go
@@ -5,7 +5,7 @@ import (
 	"github.com/ramonvermeulen/whosthere/pkg/discovery"
 )
 
-func normalizeDeviceMAC(d *discovery.Device) (string, bool) {
+func normalizedDeviceMAC(d *discovery.Device) (string, bool) {
 	if d == nil {
 		return "", false
 	}

--- a/internal/core/state/state.go
+++ b/internal/core/state/state.go
@@ -34,6 +34,7 @@ type ReadOnly interface {
 	CurrentInterface() string
 	StatusMessage() string
 	StatusSeverity() StatusSeverity
+	AliasEditorDraft() string
 }
 
 type StatusSeverity string
@@ -63,6 +64,7 @@ type AppState struct {
 	currentInterface string
 	deviceAliases    map[string]string
 	aliasLoaded      map[string]bool
+	aliasEditorDraft string
 	statusMessage    string
 	statusSeverity   StatusSeverity
 	statusUntil      time.Time
@@ -344,6 +346,25 @@ func (s *AppState) SetCurrentInterface(name string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.currentInterface = name
+}
+
+// SetAliasEditorDraft updates the current alias editor draft.
+func (s *AppState) SetAliasEditorDraft(alias string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.aliasEditorDraft = alias
+}
+
+// ClearAliasEditorDraft removes the current alias editor draft.
+func (s *AppState) ClearAliasEditorDraft() {
+	s.SetAliasEditorDraft("")
+}
+
+// AliasEditorDraft returns the current alias editor draft.
+func (s *AppState) AliasEditorDraft() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.aliasEditorDraft
 }
 
 // SetStatusMessage sets a transient status message until the given duration expires.

--- a/internal/core/state/state.go
+++ b/internal/core/state/state.go
@@ -2,7 +2,9 @@ package state
 
 import (
 	"sort"
+	"strings"
 	"sync"
+	"time"
 
 	"github.com/ramonvermeulen/whosthere/internal/core/config"
 	"github.com/ramonvermeulen/whosthere/internal/ui/theme"
@@ -15,6 +17,8 @@ type ReadOnly interface {
 	DevicesSnapshot() []*discovery.Device
 	Selected() (*discovery.Device, bool)
 	SelectedIP() string
+	AliasFor(d *discovery.Device) string
+	PreferredNameFor(d *discovery.Device) string
 	CurrentTheme() string
 	PreviousTheme() string
 	Version() string
@@ -28,7 +32,17 @@ type ReadOnly interface {
 	SearchError() bool
 	NoColor() bool
 	CurrentInterface() string
+	StatusMessage() string
+	StatusSeverity() StatusSeverity
 }
+
+type StatusSeverity string
+
+const (
+	StatusSeverityInfo    StatusSeverity = "info"
+	StatusSeveritySuccess StatusSeverity = "success"
+	StatusSeverityError   StatusSeverity = "error"
+)
 
 // AppState holds application-level state shared across views and
 // orchestrated by the App. Scanners do not write here directly.
@@ -47,14 +61,21 @@ type AppState struct {
 	searchActive     bool
 	noColor          bool
 	currentInterface string
+	deviceAliases    map[string]string
+	aliasLoaded      map[string]bool
+	statusMessage    string
+	statusSeverity   StatusSeverity
+	statusUntil      time.Time
 }
 
 func NewAppState(cfg *config.Config, version string) *AppState {
 	s := &AppState{
-		devices: make(map[string]*discovery.Device),
-		version: version,
-		cfg:     cfg,
-		noColor: theme.IsNoColor() || (cfg != nil && cfg.Theme.NoColor),
+		devices:       make(map[string]*discovery.Device),
+		version:       version,
+		cfg:           cfg,
+		noColor:       theme.IsNoColor() || (cfg != nil && cfg.Theme.NoColor),
+		deviceAliases: map[string]string{},
+		aliasLoaded:   map[string]bool{},
 	}
 	theme.UpdateNoColor(s.noColor)
 
@@ -128,6 +149,40 @@ func (s *AppState) SelectedIP() string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.selectedIP
+}
+
+// AliasFor returns the cached alias for a device, if present.
+func (s *AppState) AliasFor(d *discovery.Device) string {
+	normalizedMAC, ok := normalizeDeviceMAC(d)
+	if !ok {
+		return ""
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.deviceAliases[normalizedMAC]
+}
+
+// PreferredNameFor returns the best available display name for a device.
+func (s *AppState) PreferredNameFor(d *discovery.Device) string {
+	if d == nil {
+		return ""
+	}
+
+	if alias := s.AliasFor(d); alias != "" {
+		return alias
+	}
+	if name := d.DisplayName(); name != "" {
+		return name
+	}
+	if manufacturer := d.Manufacturer(); manufacturer != "" {
+		return manufacturer
+	}
+	if ip := d.IP(); ip != nil {
+		return ip.String()
+	}
+
+	return ""
 }
 
 // SetCurrentTheme sets the current theme.
@@ -291,6 +346,100 @@ func (s *AppState) SetCurrentInterface(name string) {
 	s.currentInterface = name
 }
 
+// SetStatusMessage sets a transient status message until the given duration expires.
+func (s *AppState) SetStatusMessage(message string, severity StatusSeverity, duration time.Duration) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.statusMessage = strings.TrimSpace(message)
+	s.statusSeverity = severity
+	if s.statusMessage == "" || duration <= 0 {
+		s.statusSeverity = StatusSeverityInfo
+		s.statusUntil = time.Time{}
+		return
+	}
+
+	s.statusUntil = time.Now().Add(duration)
+}
+
+// ClearStatusMessage removes any active transient status message.
+func (s *AppState) ClearStatusMessage() {
+	s.SetStatusMessage("", StatusSeverityInfo, 0)
+}
+
+// StatusMessage returns the active transient status message, if any.
+func (s *AppState) StatusMessage() string {
+	s.mu.RLock()
+	message := s.statusMessage
+	until := s.statusUntil
+	s.mu.RUnlock()
+
+	if message == "" {
+		return ""
+	}
+	if !until.IsZero() && time.Now().After(until) {
+		s.ClearStatusMessage()
+		return ""
+	}
+
+	return message
+}
+
+// StatusSeverity returns the severity for the current status message.
+func (s *AppState) StatusSeverity() StatusSeverity {
+	s.mu.RLock()
+	severity := s.statusSeverity
+	message := s.statusMessage
+	until := s.statusUntil
+	s.mu.RUnlock()
+
+	if message == "" {
+		return StatusSeverityInfo
+	}
+	if !until.IsZero() && time.Now().After(until) {
+		s.ClearStatusMessage()
+		return StatusSeverityInfo
+	}
+
+	return severity
+}
+
+// AliasLoaded reports whether alias metadata for a normalized MAC is cached.
+func (s *AppState) AliasLoaded(normalizedMAC string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.aliasLoaded[normalizedMAC]
+}
+
+// SetAlias caches an alias for a normalized MAC address.
+func (s *AppState) SetAlias(normalizedMAC, alias string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	alias = strings.TrimSpace(alias)
+	s.aliasLoaded[normalizedMAC] = true
+	if alias == "" {
+		delete(s.deviceAliases, normalizedMAC)
+		return
+	}
+
+	s.deviceAliases[normalizedMAC] = alias
+}
+
+// ClearAlias removes the cached alias for a normalized MAC address.
+func (s *AppState) ClearAlias(normalizedMAC string) {
+	s.SetAlias(normalizedMAC, "")
+}
+
+// ResetAliases clears all cached aliases and loaded markers.
+func (s *AppState) ResetAliases() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.deviceAliases = map[string]string{}
+	s.aliasLoaded = map[string]bool{}
+}
+
 // ClearDevices removes all discovered devices and resets selection.
 func (s *AppState) ClearDevices() {
 	s.mu.Lock()
@@ -298,4 +447,3 @@ func (s *AppState) ClearDevices() {
 	s.devices = make(map[string]*discovery.Device)
 	s.selectedIP = ""
 }
-

--- a/internal/core/state/state.go
+++ b/internal/core/state/state.go
@@ -50,7 +50,7 @@ const (
 type AppState struct {
 	mu sync.RWMutex
 
-	devices          map[string]*discovery.Device
+	devices          map[string]*deviceEntry
 	selectedIP       string
 	previousTheme    string
 	version          string
@@ -62,8 +62,6 @@ type AppState struct {
 	searchActive     bool
 	noColor          bool
 	currentInterface string
-	deviceAliases    map[string]string
-	aliasLoaded      map[string]bool
 	aliasEditorDraft string
 	statusMessage    string
 	statusSeverity   StatusSeverity
@@ -72,12 +70,10 @@ type AppState struct {
 
 func NewAppState(cfg *config.Config, version string) *AppState {
 	s := &AppState{
-		devices:       make(map[string]*discovery.Device),
-		version:       version,
-		cfg:           cfg,
-		noColor:       theme.IsNoColor() || (cfg != nil && cfg.Theme.NoColor),
-		deviceAliases: map[string]string{},
-		aliasLoaded:   map[string]bool{},
+		devices: make(map[string]*deviceEntry),
+		version: version,
+		cfg:     cfg,
+		noColor: theme.IsNoColor() || (cfg != nil && cfg.Theme.NoColor),
 	}
 	theme.UpdateNoColor(s.noColor)
 
@@ -103,13 +99,12 @@ func (s *AppState) UpsertDevice(d *discovery.Device) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if existing, ok := s.devices[key]; ok {
-		existing.Merge(d)
-		s.devices[key] = existing
-	} else {
-		// Stores a copy to prevent race conditions between discovery engine and UI rendering
-		s.devices[key] = d.Copy()
+	if existingEntry, exists := s.devices[key]; exists {
+		existingEntry.Merge(d)
+		return
 	}
+
+	s.devices[key] = newDeviceEntry(d)
 }
 
 // DevicesSnapshot returns a copy of all devices for rendering.
@@ -118,8 +113,11 @@ func (s *AppState) DevicesSnapshot() []*discovery.Device {
 	defer s.mu.RUnlock()
 
 	out := make([]*discovery.Device, 0, len(s.devices))
-	for _, d := range s.devices {
-		out = append(out, d)
+	for _, entry := range s.devices {
+		if entry == nil || entry.Device() == nil {
+			continue
+		}
+		out = append(out, entry.Device())
 	}
 	sort.Slice(out, func(i, j int) bool {
 		return discovery.CompareIPs(out[i].IP(), out[j].IP())
@@ -142,8 +140,12 @@ func (s *AppState) Selected() (*discovery.Device, bool) {
 	if s.selectedIP == "" {
 		return nil, false
 	}
-	d, ok := s.devices[s.selectedIP]
-	return d, ok
+	entry, ok := s.devices[s.selectedIP]
+	if !ok || entry == nil || entry.Device() == nil {
+		return nil, false
+	}
+
+	return entry.Device(), true
 }
 
 // SelectedIP returns the currently selected device IP, if any.
@@ -155,14 +157,19 @@ func (s *AppState) SelectedIP() string {
 
 // AliasFor returns the cached alias for a device, if present.
 func (s *AppState) AliasFor(d *discovery.Device) string {
-	normalizedMAC, ok := normalizeDeviceMAC(d)
-	if !ok {
+	if d == nil {
 		return ""
 	}
 
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.deviceAliases[normalizedMAC]
+
+	entry, ok := s.findDeviceEntryLocked(d)
+	if !ok {
+		return ""
+	}
+
+	return entry.Alias()
 }
 
 // PreferredNameFor returns the best available display name for a device.
@@ -171,20 +178,14 @@ func (s *AppState) PreferredNameFor(d *discovery.Device) string {
 		return ""
 	}
 
-	if alias := s.AliasFor(d); alias != "" {
-		return alias
-	}
-	if name := d.DisplayName(); name != "" {
-		return name
-	}
-	if manufacturer := d.Manufacturer(); manufacturer != "" {
-		return manufacturer
-	}
-	if ip := d.IP(); ip != nil {
-		return ip.String()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if entry, ok := s.findDeviceEntryLocked(d); ok {
+		return entry.PreferredName()
 	}
 
-	return ""
+	return (&deviceEntry{device: d}).PreferredName()
 }
 
 // SetCurrentTheme sets the current theme.
@@ -288,8 +289,12 @@ func (s *AppState) GetDevice(ip string) (*discovery.Device, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	device, ok := s.devices[ip]
-	return device, ok
+	entry, ok := s.devices[ip]
+	if !ok || entry == nil || entry.Device() == nil {
+		return nil, false
+	}
+
+	return entry.Device(), true
 }
 
 // SearchActive returns the search active state.
@@ -425,31 +430,35 @@ func (s *AppState) StatusSeverity() StatusSeverity {
 	return severity
 }
 
-// AliasLoaded reports whether alias metadata for a normalized MAC is cached.
-func (s *AppState) AliasLoaded(normalizedMAC string) bool {
+// HasAliasMetadataForMAC reports whether alias metadata for a normalized MAC is cached.
+func (s *AppState) HasAliasMetadataForMAC(normalizedMAC string) bool {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
-	return s.aliasLoaded[normalizedMAC]
+
+	for _, entry := range s.devices {
+		if entry != nil && entry.HasMAC(normalizedMAC) {
+			return entry.AliasMetadataLoaded()
+		}
+	}
+
+	return false
 }
 
-// SetAlias caches an alias for a normalized MAC address.
-func (s *AppState) SetAlias(normalizedMAC, alias string) {
+// SetAliasForMAC caches an alias for all devices with the given normalized MAC address.
+func (s *AppState) SetAliasForMAC(normalizedMAC, alias string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	alias = strings.TrimSpace(alias)
-	s.aliasLoaded[normalizedMAC] = true
-	if alias == "" {
-		delete(s.deviceAliases, normalizedMAC)
-		return
+	for _, entry := range s.devices {
+		if entry != nil && entry.HasMAC(normalizedMAC) {
+			entry.SetAlias(alias)
+		}
 	}
-
-	s.deviceAliases[normalizedMAC] = alias
 }
 
-// ClearAlias removes the cached alias for a normalized MAC address.
-func (s *AppState) ClearAlias(normalizedMAC string) {
-	s.SetAlias(normalizedMAC, "")
+// ClearAliasForMAC removes the cached alias for all devices with the given normalized MAC address.
+func (s *AppState) ClearAliasForMAC(normalizedMAC string) {
+	s.SetAliasForMAC(normalizedMAC, "")
 }
 
 // ResetAliases clears all cached aliases and loaded markers.
@@ -457,14 +466,42 @@ func (s *AppState) ResetAliases() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.deviceAliases = map[string]string{}
-	s.aliasLoaded = map[string]bool{}
+	for _, entry := range s.devices {
+		if entry != nil {
+			entry.ResetAlias()
+		}
+	}
 }
 
 // ClearDevices removes all discovered devices and resets selection.
 func (s *AppState) ClearDevices() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	s.devices = make(map[string]*discovery.Device)
+	s.devices = make(map[string]*deviceEntry)
 	s.selectedIP = ""
+}
+
+func (s *AppState) findDeviceEntryLocked(device *discovery.Device) (*deviceEntry, bool) {
+	if device == nil {
+		return nil, false
+	}
+
+	if ip := device.IP(); ip != nil {
+		if entry, ok := s.devices[ip.String()]; ok {
+			return entry, true
+		}
+	}
+
+	normalizedMAC, hasValidMAC := normalizedDeviceMAC(device)
+	if !hasValidMAC {
+		return nil, false
+	}
+
+	for _, entry := range s.devices {
+		if entry != nil && entry.HasMAC(normalizedMAC) {
+			return entry, true
+		}
+	}
+
+	return nil, false
 }

--- a/internal/core/state/state_test.go
+++ b/internal/core/state/state_test.go
@@ -266,6 +266,22 @@ func TestResetAliasesClearsCache(t *testing.T) {
 	}
 }
 
+func TestAliasEditorDraft(t *testing.T) {
+	t.Parallel()
+
+	appState := NewAppState(config.DefaultConfig(), "1.0.0")
+
+	appState.SetAliasEditorDraft("Living Room TV")
+	if got := appState.AliasEditorDraft(); got != "Living Room TV" {
+		t.Fatalf("AliasEditorDraft() = %q, want %q", got, "Living Room TV")
+	}
+
+	appState.ClearAliasEditorDraft()
+	if got := appState.AliasEditorDraft(); got != "" {
+		t.Fatalf("AliasEditorDraft() after clear = %q, want empty", got)
+	}
+}
+
 func TestStatusMessageLifecycle(t *testing.T) {
 	t.Parallel()
 

--- a/internal/core/state/state_test.go
+++ b/internal/core/state/state_test.go
@@ -3,6 +3,7 @@ package state
 import (
 	"net"
 	"testing"
+	"time"
 
 	"github.com/ramonvermeulen/whosthere/internal/core/config"
 	"github.com/ramonvermeulen/whosthere/pkg/discovery"
@@ -181,5 +182,108 @@ func TestSearch(t *testing.T) {
 	state.SetFilterPattern("search")
 	if state.SearchText() != "search" {
 		t.Errorf("expected search text search, got %s", state.SearchText())
+	}
+}
+
+func TestPreferredNameForAliasPrecedence(t *testing.T) {
+	t.Parallel()
+
+	appState := NewAppState(config.DefaultConfig(), "1.0.0")
+
+	device := discovery.NewDevice(net.ParseIP("192.168.1.42"))
+	device.SetMAC("AA:BB:CC:DD:EE:FF")
+	device.SetDisplayName("Detected Device")
+	device.SetManufacturer("Acme")
+
+	if got := appState.PreferredNameFor(device); got != "Detected Device" {
+		t.Fatalf("PreferredNameFor() without alias = %q, want %q", got, "Detected Device")
+	}
+
+	appState.SetAlias("aa:bb:cc:dd:ee:ff", "Desk Speaker")
+
+	if got := appState.AliasFor(device); got != "Desk Speaker" {
+		t.Fatalf("AliasFor() = %q, want %q", got, "Desk Speaker")
+	}
+	if got := appState.PreferredNameFor(device); got != "Desk Speaker" {
+		t.Fatalf("PreferredNameFor() with alias = %q, want %q", got, "Desk Speaker")
+	}
+}
+
+func TestPreferredNameForFallsBackToManufacturerAndIP(t *testing.T) {
+	t.Parallel()
+
+	appState := NewAppState(config.DefaultConfig(), "1.0.0")
+
+	device := discovery.NewDevice(net.ParseIP("192.168.1.99"))
+	device.SetManufacturer("Vendor")
+	if got := appState.PreferredNameFor(device); got != "Vendor" {
+		t.Fatalf("PreferredNameFor() manufacturer fallback = %q, want %q", got, "Vendor")
+	}
+
+	device.SetManufacturer("")
+	if got := appState.PreferredNameFor(device); got != "192.168.1.99" {
+		t.Fatalf("PreferredNameFor() IP fallback = %q, want %q", got, "192.168.1.99")
+	}
+}
+
+func TestSetAliasMarksAliasLoaded(t *testing.T) {
+	t.Parallel()
+
+	appState := NewAppState(config.DefaultConfig(), "1.0.0")
+	const mac = "aa:bb:cc:dd:ee:ff"
+
+	if appState.AliasLoaded(mac) {
+		t.Fatal("AliasLoaded() = true before caching, want false")
+	}
+
+	appState.ClearAlias(mac)
+	if !appState.AliasLoaded(mac) {
+		t.Fatal("AliasLoaded() = false after ClearAlias, want true")
+	}
+}
+
+func TestResetAliasesClearsCache(t *testing.T) {
+	t.Parallel()
+
+	appState := NewAppState(config.DefaultConfig(), "1.0.0")
+	const mac = "aa:bb:cc:dd:ee:ff"
+
+	device := discovery.NewDevice(net.ParseIP("192.168.1.10"))
+	device.SetMAC("AA:BB:CC:DD:EE:FF")
+	appState.SetAlias(mac, "Laptop")
+
+	if got := appState.AliasFor(device); got != "Laptop" {
+		t.Fatalf("AliasFor() before reset = %q, want %q", got, "Laptop")
+	}
+
+	appState.ResetAliases()
+
+	if got := appState.AliasFor(device); got != "" {
+		t.Fatalf("AliasFor() after reset = %q, want empty", got)
+	}
+	if appState.AliasLoaded(mac) {
+		t.Fatal("AliasLoaded() after reset = true, want false")
+	}
+}
+
+func TestStatusMessageLifecycle(t *testing.T) {
+	t.Parallel()
+
+	appState := NewAppState(config.DefaultConfig(), "1.0.0")
+
+	appState.SetStatusMessage("alias saved", StatusSeveritySuccess, 50*time.Millisecond)
+	if got := appState.StatusMessage(); got != "alias saved" {
+		t.Fatalf("StatusMessage() = %q, want %q", got, "alias saved")
+	}
+	if got := appState.StatusSeverity(); got != StatusSeveritySuccess {
+		t.Fatalf("StatusSeverity() = %q, want %q", got, StatusSeveritySuccess)
+	}
+
+	time.Sleep(75 * time.Millisecond)
+	if got := appState.StatusMessage(); got != "" {
+		t.Fatalf("StatusMessage() after expiry = %q, want empty", got)
+	}
+	if got := appState.StatusSeverity(); got != StatusSeverityInfo {
+		t.Fatalf("StatusSeverity() after expiry = %q, want %q", got, StatusSeverityInfo)
 	}
 }

--- a/internal/core/state/state_test.go
+++ b/internal/core/state/state_test.go
@@ -199,7 +199,8 @@ func TestPreferredNameForAliasPrecedence(t *testing.T) {
 		t.Fatalf("PreferredNameFor() without alias = %q, want %q", got, "Detected Device")
 	}
 
-	appState.SetAlias("aa:bb:cc:dd:ee:ff", "Desk Speaker")
+	appState.UpsertDevice(device)
+	appState.SetAliasForMAC("aa:bb:cc:dd:ee:ff", "Desk Speaker")
 
 	if got := appState.AliasFor(device); got != "Desk Speaker" {
 		t.Fatalf("AliasFor() = %q, want %q", got, "Desk Speaker")
@@ -231,14 +232,17 @@ func TestSetAliasMarksAliasLoaded(t *testing.T) {
 
 	appState := NewAppState(config.DefaultConfig(), "1.0.0")
 	const mac = "aa:bb:cc:dd:ee:ff"
+	device := discovery.NewDevice(net.ParseIP("192.168.1.10"))
+	device.SetMAC("AA:BB:CC:DD:EE:FF")
+	appState.UpsertDevice(device)
 
-	if appState.AliasLoaded(mac) {
-		t.Fatal("AliasLoaded() = true before caching, want false")
+	if appState.HasAliasMetadataForMAC(mac) {
+		t.Fatal("HasAliasMetadataForMAC() = true before caching, want false")
 	}
 
-	appState.ClearAlias(mac)
-	if !appState.AliasLoaded(mac) {
-		t.Fatal("AliasLoaded() = false after ClearAlias, want true")
+	appState.ClearAliasForMAC(mac)
+	if !appState.HasAliasMetadataForMAC(mac) {
+		t.Fatal("HasAliasMetadataForMAC() = false after ClearAliasForMAC, want true")
 	}
 }
 
@@ -250,7 +254,8 @@ func TestResetAliasesClearsCache(t *testing.T) {
 
 	device := discovery.NewDevice(net.ParseIP("192.168.1.10"))
 	device.SetMAC("AA:BB:CC:DD:EE:FF")
-	appState.SetAlias(mac, "Laptop")
+	appState.UpsertDevice(device)
+	appState.SetAliasForMAC(mac, "Laptop")
 
 	if got := appState.AliasFor(device); got != "Laptop" {
 		t.Fatalf("AliasFor() before reset = %q, want %q", got, "Laptop")
@@ -261,8 +266,8 @@ func TestResetAliasesClearsCache(t *testing.T) {
 	if got := appState.AliasFor(device); got != "" {
 		t.Fatalf("AliasFor() after reset = %q, want empty", got)
 	}
-	if appState.AliasLoaded(mac) {
-		t.Fatal("AliasLoaded() after reset = true, want false")
+	if appState.HasAliasMetadataForMAC(mac) {
+		t.Fatal("HasAliasMetadataForMAC() after reset = true, want false")
 	}
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -45,7 +45,6 @@ type App struct {
 	clipboard     *clipboard.Clipboard
 	logger        *slog.Logger
 	metaStore     devicemeta.Store
-	aliasEditor   *views.AliasModalView
 	stopOnce      sync.Once
 
 	// Engine lifecycle management for runtime interface switching.
@@ -172,7 +171,6 @@ func (a *App) setupPages(cfg *config.Config) {
 	a.pages.AddPage(routes.RouteInterfacePicker, interfacePickerModal, true, false)
 	a.pages.AddPage(routes.RouteAliasEditor, aliasModal, true, false)
 	a.pages.AddPage(routes.RouteAliasReset, resetAliasesModal, true, false)
-	a.aliasEditor = aliasModal
 
 	initialPage := routes.RouteDashboard
 	if cfg != nil && cfg.Splash.Enabled {
@@ -341,6 +339,9 @@ func (a *App) handleEvents() {
 			a.state.SetPreviousTheme(a.state.CurrentTheme())
 		case events.HideView:
 			front, _ := a.pages.GetFrontPage()
+			if front == routes.RouteAliasEditor {
+				a.state.ClearAliasEditorDraft()
+			}
 			a.pages.HidePage(front)
 			a.resetFocus()
 		case events.DiscoveryStarted:
@@ -359,6 +360,8 @@ func (a *App) handleEvents() {
 			a.state.SetSearchError(event.Error)
 		case events.SearchFinished:
 			a.state.SetSearchActive(false)
+		case events.AliasDraftChanged:
+			a.state.SetAliasEditorDraft(event.Alias)
 		case events.CopyIP:
 			var ip string
 			if event.IP != "" {
@@ -528,9 +531,7 @@ func (a *App) openAliasEditor() {
 		return
 	}
 
-	if a.aliasEditor != nil {
-		a.aliasEditor.Prepare(device.MAC(), a.state.AliasFor(device))
-	}
+	a.state.SetAliasEditorDraft(a.state.AliasFor(device))
 	a.emit(events.NavigateTo{Route: routes.RouteAliasEditor, Overlay: true})
 }
 
@@ -554,6 +555,7 @@ func (a *App) saveAlias(alias string) {
 		a.state.SetStatusMessage("Alias saved", state.StatusSeveritySuccess, statusMessageTTL)
 	}
 
+	a.state.ClearAliasEditorDraft()
 	a.emit(events.HideView{})
 	a.logger.Info("device alias saved", "mac", normalizedMAC, "ip", device.IP().String())
 }

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -236,10 +236,10 @@ func (a *App) handleEngineEvents(ctx context.Context, engine *discovery.Engine, 
 			a.emit(events.DiscoveryStopped{})
 		case discovery.EventDeviceDiscovered:
 			if event.Device != nil {
-				a.cacheAliasForDevice(event.Device)
 				a.engineMu.RLock()
 				if a.engineGen.Load() == gen {
 					a.state.UpsertDevice(event.Device)
+					a.cacheAliasForDevice(event.Device)
 				}
 				a.engineMu.RUnlock()
 			}
@@ -501,8 +501,8 @@ func (a *App) cacheAliasForDevice(device *discovery.Device) {
 		return
 	}
 
-	normalizedMAC, ok := devicemeta.NormalizeMAC(device.MAC())
-	if !ok || a.state.AliasLoaded(normalizedMAC) {
+	normalizedMAC, hasValidMAC := devicemeta.NormalizeMAC(device.MAC())
+	if !hasValidMAC || a.state.HasAliasMetadataForMAC(normalizedMAC) {
 		return
 	}
 
@@ -513,11 +513,11 @@ func (a *App) cacheAliasForDevice(device *discovery.Device) {
 	}
 
 	if found {
-		a.state.SetAlias(normalizedMAC, record.Alias)
+		a.state.SetAliasForMAC(normalizedMAC, record.Alias)
 		return
 	}
 
-	a.state.ClearAlias(normalizedMAC)
+	a.state.ClearAliasForMAC(normalizedMAC)
 }
 
 func (a *App) openAliasEditor() {
@@ -548,10 +548,10 @@ func (a *App) saveAlias(alias string) {
 	}
 
 	if alias == "" {
-		a.state.ClearAlias(normalizedMAC)
+		a.state.ClearAliasForMAC(normalizedMAC)
 		a.state.SetStatusMessage("Alias cleared", state.StatusSeveritySuccess, statusMessageTTL)
 	} else {
-		a.state.SetAlias(normalizedMAC, alias)
+		a.state.SetAliasForMAC(normalizedMAC, alias)
 		a.state.SetStatusMessage("Alias saved", state.StatusSeveritySuccess, statusMessageTTL)
 	}
 
@@ -572,7 +572,7 @@ func (a *App) clearAlias() {
 		return
 	}
 
-	a.state.ClearAlias(normalizedMAC)
+	a.state.ClearAliasForMAC(normalizedMAC)
 	a.state.SetStatusMessage("Alias cleared", state.StatusSeveritySuccess, statusMessageTTL)
 }
 

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gdamore/tcell/v2"
 	"github.com/ramonvermeulen/whosthere/internal/core"
 	"github.com/ramonvermeulen/whosthere/internal/core/config"
+	"github.com/ramonvermeulen/whosthere/internal/core/devicemeta"
 	"github.com/ramonvermeulen/whosthere/internal/core/state"
 	"github.com/ramonvermeulen/whosthere/internal/ui/events"
 	"github.com/ramonvermeulen/whosthere/internal/ui/routes"
@@ -25,7 +26,8 @@ import (
 )
 
 const (
-	refreshInterval = 1 * time.Second
+	refreshInterval  = 1 * time.Second
+	statusMessageTTL = 1500 * time.Millisecond
 )
 
 // App represents the main TUI application.
@@ -42,6 +44,9 @@ type App struct {
 	isReady       bool
 	clipboard     *clipboard.Clipboard
 	logger        *slog.Logger
+	metaStore     devicemeta.Store
+	aliasEditor   *views.AliasModalView
+	stopOnce      sync.Once
 
 	// Engine lifecycle management for runtime interface switching.
 	// When the user switches network interface, the old engine must stop cleanly
@@ -59,6 +64,11 @@ func NewApp(cfg *config.Config, logger *slog.Logger, version string) (*App, erro
 		logger = slog.Default()
 	}
 
+	metaStore, err := devicemeta.OpenDefault()
+	if err != nil {
+		return nil, fmt.Errorf("open device metadata store: %w", err)
+	}
+
 	a := &App{
 		Application: app,
 		state:       appState,
@@ -66,6 +76,7 @@ func NewApp(cfg *config.Config, logger *slog.Logger, version string) (*App, erro
 		events:      make(chan events.Event, 100),
 		clipboard:   clipboard.New(clipboard.ClipboardOptions{Primary: false}),
 		logger:      logger,
+		metaStore:   metaStore,
 	}
 	a.setupSignalHandler()
 
@@ -150,6 +161,8 @@ func (a *App) setupPages(cfg *config.Config) {
 	themePickerModal := views.NewThemeModalView(a.emit)
 	portScanModal := views.NewPortScanModalView(a.emit)
 	interfacePickerModal := views.NewInterfaceModalView(a.emit)
+	aliasModal := views.NewAliasModalView(a.emit)
+	resetAliasesModal := views.NewResetAliasesModalView(a.emit)
 
 	a.pages.AddPage(routes.RouteDashboard, dashboardPage, true, false)
 	a.pages.AddPage(routes.RouteDetail, detailPage, true, false)
@@ -157,6 +170,9 @@ func (a *App) setupPages(cfg *config.Config) {
 	a.pages.AddPage(routes.RouteThemePicker, themePickerModal, true, false)
 	a.pages.AddPage(routes.RoutePortScan, portScanModal, true, false)
 	a.pages.AddPage(routes.RouteInterfacePicker, interfacePickerModal, true, false)
+	a.pages.AddPage(routes.RouteAliasEditor, aliasModal, true, false)
+	a.pages.AddPage(routes.RouteAliasReset, resetAliasesModal, true, false)
+	a.aliasEditor = aliasModal
 
 	initialPage := routes.RouteDashboard
 	if cfg != nil && cfg.Splash.Enabled {
@@ -175,6 +191,9 @@ func (a *App) handleGlobalKeys(event *tcell.EventKey) *tcell.EventKey {
 		return nil
 	case tcell.KeyCtrlI:
 		a.emit(events.NavigateTo{Route: routes.RouteInterfacePicker, Overlay: true})
+		return nil
+	case tcell.KeyCtrlR:
+		a.emit(events.AliasesResetRequested{})
 		return nil
 	case tcell.KeyRune:
 		if event.Rune() == 'q' || event.Rune() == 'Q' {
@@ -219,6 +238,7 @@ func (a *App) handleEngineEvents(ctx context.Context, engine *discovery.Engine, 
 			a.emit(events.DiscoveryStopped{})
 		case discovery.EventDeviceDiscovered:
 			if event.Device != nil {
+				a.cacheAliasForDevice(event.Device)
 				a.engineMu.RLock()
 				if a.engineGen.Load() == gen {
 					a.state.UpsertDevice(event.Device)
@@ -371,9 +391,40 @@ func (a *App) handleEvents() {
 			}
 		case events.InterfaceSelected:
 			go a.switchInterface(event.Name)
+		case events.AliasEditRequested:
+			a.openAliasEditor()
+		case events.AliasSubmitted:
+			a.saveAlias(event.Alias)
+		case events.AliasCleared:
+			a.clearAlias()
+		case events.AliasesResetRequested:
+			a.emit(events.NavigateTo{Route: routes.RouteAliasReset, Overlay: true})
+		case events.AliasesResetConfirmed:
+			a.resetAliases()
 		}
 		a.rerenderVisibleViews()
 	}
+}
+
+// Stop shuts down app-owned resources before stopping the TUI application.
+func (a *App) Stop() {
+	a.stopOnce.Do(func() {
+		if a.refreshTicker != nil {
+			a.refreshTicker.Stop()
+		}
+		if a.engineCancel != nil {
+			a.engineCancel()
+		}
+		if a.engine != nil {
+			go a.engine.Stop()
+		}
+		if a.metaStore != nil {
+			if err := a.metaStore.Close(); err != nil {
+				a.logger.Warn("failed to close metadata store", "error", err)
+			}
+		}
+		a.Application.Stop()
+	})
 }
 
 func (a *App) startPortscan() {
@@ -440,4 +491,117 @@ func (a *App) switchInterface(name string) {
 
 	a.engine.Start(context.Background())
 	go a.handleEngineEvents(ctx, engine, gen)
+}
+
+func (a *App) cacheAliasForDevice(device *discovery.Device) {
+	if device == nil || a.metaStore == nil {
+		return
+	}
+
+	normalizedMAC, ok := devicemeta.NormalizeMAC(device.MAC())
+	if !ok || a.state.AliasLoaded(normalizedMAC) {
+		return
+	}
+
+	record, found, err := a.metaStore.Get(normalizedMAC)
+	if err != nil {
+		a.logger.Warn("failed to load device alias", "mac", normalizedMAC, "error", err)
+		return
+	}
+
+	if found {
+		a.state.SetAlias(normalizedMAC, record.Alias)
+		return
+	}
+
+	a.state.ClearAlias(normalizedMAC)
+}
+
+func (a *App) openAliasEditor() {
+	device, ok := a.state.Selected()
+	if !ok {
+		return
+	}
+
+	if _, validMAC := devicemeta.NormalizeMAC(device.MAC()); !validMAC {
+		a.logger.Warn("cannot edit alias for device without a valid MAC", "ip", device.IP().String())
+		return
+	}
+
+	if a.aliasEditor != nil {
+		a.aliasEditor.Prepare(device.MAC(), a.state.AliasFor(device))
+	}
+	a.emit(events.NavigateTo{Route: routes.RouteAliasEditor, Overlay: true})
+}
+
+func (a *App) saveAlias(alias string) {
+	device, normalizedMAC, ok := a.selectedDeviceMAC()
+	if !ok {
+		return
+	}
+
+	if err := a.metaStore.SetAlias(normalizedMAC, alias); err != nil {
+		a.logger.Error("failed to save device alias", "mac", normalizedMAC, "error", err)
+		a.state.SetStatusMessage("Failed to save alias", state.StatusSeverityError, statusMessageTTL)
+		return
+	}
+
+	if alias == "" {
+		a.state.ClearAlias(normalizedMAC)
+		a.state.SetStatusMessage("Alias cleared", state.StatusSeveritySuccess, statusMessageTTL)
+	} else {
+		a.state.SetAlias(normalizedMAC, alias)
+		a.state.SetStatusMessage("Alias saved", state.StatusSeveritySuccess, statusMessageTTL)
+	}
+
+	a.emit(events.HideView{})
+	a.logger.Info("device alias saved", "mac", normalizedMAC, "ip", device.IP().String())
+}
+
+func (a *App) clearAlias() {
+	_, normalizedMAC, ok := a.selectedDeviceMAC()
+	if !ok {
+		return
+	}
+
+	if err := a.metaStore.ClearAlias(normalizedMAC); err != nil {
+		a.logger.Error("failed to clear device alias", "mac", normalizedMAC, "error", err)
+		a.state.SetStatusMessage("Failed to clear alias", state.StatusSeverityError, statusMessageTTL)
+		return
+	}
+
+	a.state.ClearAlias(normalizedMAC)
+	a.state.SetStatusMessage("Alias cleared", state.StatusSeveritySuccess, statusMessageTTL)
+}
+
+func (a *App) resetAliases() {
+	if a.metaStore == nil {
+		return
+	}
+
+	if err := a.metaStore.ResetAliases(); err != nil {
+		a.logger.Error("failed to reset aliases", "error", err)
+		a.state.SetStatusMessage("Failed to reset aliases", state.StatusSeverityError, statusMessageTTL)
+		return
+	}
+
+	a.state.ResetAliases()
+	a.state.SetStatusMessage("All aliases cleared", state.StatusSeveritySuccess, statusMessageTTL)
+	a.emit(events.HideView{})
+	a.logger.Info("all device aliases cleared")
+}
+
+func (a *App) selectedDeviceMAC() (*discovery.Device, string, bool) {
+	device, ok := a.state.Selected()
+	if !ok {
+		return nil, "", false
+	}
+
+	normalizedMAC, validMAC := devicemeta.NormalizeMAC(device.MAC())
+	if !validMAC {
+		a.logger.Warn("selected device has no valid MAC address", "ip", device.IP().String())
+		return nil, "", false
+	}
+
+	return device, normalizedMAC, true
 }

--- a/internal/ui/components/device_table.go
+++ b/internal/ui/components/device_table.go
@@ -24,6 +24,7 @@ type DeviceTable struct {
 	filterRE    *regexp.Regexp
 	searching   bool
 	searchInput string
+	state       state.ReadOnly
 
 	emit func(events.Event)
 }
@@ -167,6 +168,7 @@ func (dt *DeviceTable) applySearch(pattern string) {
 
 // Render updates the table with the latest devices from state.
 func (dt *DeviceTable) Render(st state.ReadOnly) {
+	dt.state = st
 	dt.devices = st.DevicesSnapshot()
 	_ = dt.SetFilter(st.FilterPattern())
 }
@@ -222,18 +224,27 @@ func (dt *DeviceTable) moveSelection(delta int) {
 }
 
 type tableRow struct {
-	ip, hostname, mac, manufacturer, lastSeen string
+	ip, hostname, mac, manufacturer, lastSeen, alias, detectedName string
 }
 
 func (dt *DeviceTable) buildRows() []tableRow {
 	rows := make([]tableRow, 0, len(dt.devices))
 	for _, d := range dt.devices {
+		hostname := d.DisplayName()
+		alias := ""
+		if dt.state != nil {
+			hostname = dt.state.PreferredNameFor(d)
+			alias = dt.state.AliasFor(d)
+		}
+
 		row := tableRow{
 			ip:           d.IP().String(),
-			hostname:     d.DisplayName(),
+			hostname:     hostname,
 			mac:          d.MAC(),
 			manufacturer: d.Manufacturer(),
 			lastSeen:     utils.FmtDuration(time.Since(d.LastSeen())),
+			alias:        alias,
+			detectedName: d.DisplayName(),
 		}
 		if dt.filterRE != nil && !dt.rowMatches(&row) {
 			continue
@@ -248,7 +259,7 @@ func (dt *DeviceTable) refresh() {
 	dt.Clear()
 	const maxColWidth = 30
 
-	headers := []string{"IP", "Display Name", "MAC", "Manufacturer", "Last Seen"}
+	headers := []string{"IP", "Name", "MAC", "Manufacturer", "Last Seen"}
 
 	for i, h := range headers {
 		text := utils.Truncate(h, maxColWidth)
@@ -306,5 +317,7 @@ func (dt *DeviceTable) rowMatches(r *tableRow) bool {
 		dt.filterRE.MatchString(r.hostname) ||
 		dt.filterRE.MatchString(r.mac) ||
 		dt.filterRE.MatchString(r.manufacturer) ||
+		dt.filterRE.MatchString(r.alias) ||
+		dt.filterRE.MatchString(r.detectedName) ||
 		dt.filterRE.MatchString(r.lastSeen)
 }

--- a/internal/ui/components/device_table_test.go
+++ b/internal/ui/components/device_table_test.go
@@ -17,7 +17,7 @@ func TestDeviceTableRenderUsesPreferredName(t *testing.T) {
 	device.SetMAC("AA:BB:CC:DD:EE:FF")
 	device.SetDisplayName("Detected Host")
 	appState.UpsertDevice(device)
-	appState.SetAlias("aa:bb:cc:dd:ee:ff", "Kitchen Tablet")
+	appState.SetAliasForMAC("aa:bb:cc:dd:ee:ff", "Kitchen Tablet")
 
 	table := NewDeviceTable(nil)
 	table.Render(appState.ReadOnly())
@@ -35,7 +35,7 @@ func TestDeviceTableFilterMatchesAliasAndDetectedName(t *testing.T) {
 	device.SetMAC("AA:BB:CC:DD:EE:11")
 	device.SetDisplayName("Detected Printer")
 	appState.UpsertDevice(device)
-	appState.SetAlias("aa:bb:cc:dd:ee:11", "Office Printer")
+	appState.SetAliasForMAC("aa:bb:cc:dd:ee:11", "Office Printer")
 
 	table := NewDeviceTable(nil)
 	table.Render(appState.ReadOnly())

--- a/internal/ui/components/device_table_test.go
+++ b/internal/ui/components/device_table_test.go
@@ -1,0 +1,56 @@
+package components
+
+import (
+	"net"
+	"testing"
+
+	"github.com/ramonvermeulen/whosthere/internal/core/config"
+	"github.com/ramonvermeulen/whosthere/internal/core/state"
+	"github.com/ramonvermeulen/whosthere/pkg/discovery"
+)
+
+func TestDeviceTableRenderUsesPreferredName(t *testing.T) {
+	t.Parallel()
+
+	appState := state.NewAppState(config.DefaultConfig(), "1.0.0")
+	device := discovery.NewDevice(net.ParseIP("192.168.1.10"))
+	device.SetMAC("AA:BB:CC:DD:EE:FF")
+	device.SetDisplayName("Detected Host")
+	appState.UpsertDevice(device)
+	appState.SetAlias("aa:bb:cc:dd:ee:ff", "Kitchen Tablet")
+
+	table := NewDeviceTable(nil)
+	table.Render(appState.ReadOnly())
+
+	if got := table.GetCell(1, 1).Text; got != "Kitchen Tablet" {
+		t.Fatalf("table hostname cell = %q, want %q", got, "Kitchen Tablet")
+	}
+}
+
+func TestDeviceTableFilterMatchesAliasAndDetectedName(t *testing.T) {
+	t.Parallel()
+
+	appState := state.NewAppState(config.DefaultConfig(), "1.0.0")
+	device := discovery.NewDevice(net.ParseIP("192.168.1.11"))
+	device.SetMAC("AA:BB:CC:DD:EE:11")
+	device.SetDisplayName("Detected Printer")
+	appState.UpsertDevice(device)
+	appState.SetAlias("aa:bb:cc:dd:ee:11", "Office Printer")
+
+	table := NewDeviceTable(nil)
+	table.Render(appState.ReadOnly())
+
+	if err := table.SetFilter("Office"); err != nil {
+		t.Fatalf("SetFilter(alias) error = %v", err)
+	}
+	if table.GetRowCount() != 2 {
+		t.Fatalf("row count after alias filter = %d, want 2", table.GetRowCount())
+	}
+
+	if err := table.SetFilter("Detected"); err != nil {
+		t.Fatalf("SetFilter(detected name) error = %v", err)
+	}
+	if table.GetRowCount() != 2 {
+		t.Fatalf("row count after detected-name filter = %d, want 2", table.GetRowCount())
+	}
+}

--- a/internal/ui/components/status_bar.go
+++ b/internal/ui/components/status_bar.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"github.com/gdamore/tcell/v2"
 	"github.com/ramonvermeulen/whosthere/internal/core/state"
 	"github.com/ramonvermeulen/whosthere/internal/ui/theme"
 	"github.com/rivo/tview"
@@ -11,8 +12,9 @@ var _ UIComponent = &StatusBar{}
 // StatusBar combines a Spinner with a right-aligned help text into a single flex row.
 type StatusBar struct {
 	*tview.Flex
-	spinner *Spinner
-	help    *tview.TextView
+	spinner  *Spinner
+	help     *tview.TextView
+	helpText string
 }
 
 func NewStatusBar() *StatusBar {
@@ -40,10 +42,43 @@ func (s *StatusBar) SetHelp(text string) {
 	if s == nil || s.help == nil {
 		return
 	}
+	s.helpText = text
 	s.help.SetText(text)
 }
 
 // Render implements UIComponent.
-func (s *StatusBar) Render(_ state.ReadOnly) {
-	// StatusBar is updated via SetHelp, no state update needed.
+func (s *StatusBar) Render(st state.ReadOnly) {
+	if s == nil || s.help == nil {
+		return
+	}
+
+	if st == nil {
+		s.help.SetText(s.helpText)
+		s.help.SetTextColor(tview.Styles.PrimaryTextColor)
+		return
+	}
+
+	if message := st.StatusMessage(); message != "" {
+		s.help.SetText(message)
+		s.help.SetTextColor(statusSeverityColor(st))
+		return
+	}
+
+	s.help.SetText(s.helpText)
+	s.help.SetTextColor(tview.Styles.PrimaryTextColor)
+}
+
+func statusSeverityColor(st state.ReadOnly) tcell.Color {
+	if st == nil || st.NoColor() {
+		return tview.Styles.PrimaryTextColor
+	}
+
+	switch st.StatusSeverity() {
+	case state.StatusSeverityError:
+		return tcell.ColorRed
+	case state.StatusSeveritySuccess:
+		return tview.Styles.ContrastSecondaryTextColor
+	default:
+		return tview.Styles.SecondaryTextColor
+	}
 }

--- a/internal/ui/events/events.go
+++ b/internal/ui/events/events.go
@@ -81,6 +81,11 @@ type AliasSubmitted struct {
 	Alias string
 }
 
+// AliasDraftChanged updates the in-progress alias editor text.
+type AliasDraftChanged struct {
+	Alias string
+}
+
 // AliasCleared removes the alias for the selected device.
 type AliasCleared struct{}
 

--- a/internal/ui/events/events.go
+++ b/internal/ui/events/events.go
@@ -73,3 +73,19 @@ type InterfaceSelected struct {
 	Name string
 }
 
+// AliasEditRequested opens the alias editor for the selected device.
+type AliasEditRequested struct{}
+
+// AliasSubmitted saves the currently entered alias for the selected device.
+type AliasSubmitted struct {
+	Alias string
+}
+
+// AliasCleared removes the alias for the selected device.
+type AliasCleared struct{}
+
+// AliasesResetRequested opens the reset-all-aliases confirmation modal.
+type AliasesResetRequested struct{}
+
+// AliasesResetConfirmed clears all persisted aliases.
+type AliasesResetConfirmed struct{}

--- a/internal/ui/routes/navigation.go
+++ b/internal/ui/routes/navigation.go
@@ -7,4 +7,6 @@ const (
 	RouteThemePicker     = "theme-picker"
 	RoutePortScan        = "port-scan"
 	RouteInterfacePicker = "interface-picker"
+	RouteAliasEditor     = "alias-editor"
+	RouteAliasReset      = "alias-reset"
 )

--- a/internal/ui/theme/theme.go
+++ b/internal/ui/theme/theme.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/ramonvermeulen/whosthere/internal/core/config"
@@ -15,6 +16,7 @@ import (
 var log = slog.Default()
 
 var noColor = os.Getenv("NO_COLOR") != "" || os.Getenv("WHOSTHERE__THEME__NO_COLOR") != ""
+var noColorMu sync.RWMutex
 
 var registry = map[string]tview.Theme{
 	config.DefaultThemeName: {
@@ -847,6 +849,7 @@ var registry = map[string]tview.Theme{
 }
 
 var primitives []tview.Primitive
+var primitivesMu sync.RWMutex
 
 // Resolve returns the theme by name. Unknown names fall back to default; "custom" applies overrides atop default.
 func Resolve(tc *config.ThemeConfig) tview.Theme {
@@ -942,12 +945,18 @@ func Names() []string {
 // RegisterPrimitive registers a primitive for theme updates.
 func RegisterPrimitive(p tview.Primitive) {
 	ApplyToPrimitive(p)
+	primitivesMu.Lock()
+	defer primitivesMu.Unlock()
 	primitives = append(primitives, p)
 }
 
 // ApplyThemeToAllRegisteredPrimitives applies the current theme to all registered primitives.
 func ApplyThemeToAllRegisteredPrimitives() {
-	for _, p := range primitives {
+	primitivesMu.RLock()
+	snapshot := append([]tview.Primitive(nil), primitives...)
+	primitivesMu.RUnlock()
+
+	for _, p := range snapshot {
 		ApplyToPrimitive(p)
 	}
 }
@@ -974,6 +983,8 @@ func ApplyToPrimitive(p tview.Primitive) {
 		return
 	}
 
+	currentNoColor := IsNoColor()
+
 	switch v := p.(type) {
 	case *tview.TextView:
 		v.SetTextColor(tview.Styles.PrimaryTextColor)
@@ -993,7 +1004,7 @@ func ApplyToPrimitive(p tview.Primitive) {
 		v.SetBordersColor(tview.Styles.BorderColor)
 		v.SetBackgroundColor(tview.Styles.PrimitiveBackgroundColor)
 		v.SetBorderColor(tview.Styles.BorderColor)
-		if noColor {
+		if currentNoColor {
 			if tview.Styles.PrimaryTextColor == tcell.ColorDefault {
 				selectedStyle := tcell.StyleDefault.Reverse(true)
 				v.SetSelectedStyle(selectedStyle)
@@ -1022,7 +1033,7 @@ func ApplyToPrimitive(p tview.Primitive) {
 		v.SetBackgroundColor(tview.Styles.PrimitiveBackgroundColor)
 		v.SetBorderColor(tview.Styles.BorderColor)
 		v.SetTitleColor(tview.Styles.TitleColor)
-		if noColor {
+		if currentNoColor {
 			selectedStyle := tcell.StyleDefault.Reverse(true)
 			v.SetSelectedStyle(selectedStyle)
 		}
@@ -1082,7 +1093,7 @@ func ApplyToPrimitive(p tview.Primitive) {
 			Foreground(tview.Styles.BorderColor).
 			Background(tview.Styles.PrimitiveBackgroundColor))
 		v.SetTitleColor(tview.Styles.TitleColor)
-		if noColor {
+		if currentNoColor {
 			buttonStyle := tcell.StyleDefault.Reverse(true)
 			v.SetButtonActivatedStyle(buttonStyle)
 		}
@@ -1141,9 +1152,13 @@ func IsNoColor() bool {
 	// todo(ramon): fix issue where if NoColor is set via config, this is not detected here
 	// thus for all `--help` output the colors will still be enabled, which is not ideal.
 	// consider if it is worth parsing config earlier to prevent this
+	noColorMu.RLock()
+	defer noColorMu.RUnlock()
 	return noColor
 }
 
 func UpdateNoColor(updateNoColor bool) {
-       noColor = updateNoColor
+	noColorMu.Lock()
+	defer noColorMu.Unlock()
+	noColor = updateNoColor
 }

--- a/internal/ui/views/alias_modal.go
+++ b/internal/ui/views/alias_modal.go
@@ -1,0 +1,95 @@
+package views
+
+import (
+	"fmt"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/ramonvermeulen/whosthere/internal/core/state"
+	"github.com/ramonvermeulen/whosthere/internal/ui/components"
+	"github.com/ramonvermeulen/whosthere/internal/ui/events"
+	"github.com/ramonvermeulen/whosthere/internal/ui/theme"
+	"github.com/rivo/tview"
+)
+
+var _ View = &AliasModalView{}
+
+// AliasModalView is a modal overlay for editing the selected device alias.
+type AliasModalView struct {
+	*tview.Flex
+	input      *tview.InputField
+	footer     *tview.TextView
+	currentMAC string
+}
+
+func NewAliasModalView(emit func(events.Event)) *AliasModalView {
+	input := tview.NewInputField().
+		SetLabel("Alias: ").
+		SetFieldWidth(36)
+	input.SetBorder(true).SetTitle(" Device Alias ")
+	input.SetDoneFunc(func(key tcell.Key) {
+		switch key {
+		case tcell.KeyEnter:
+			emit(events.AliasSubmitted{Alias: input.GetText()})
+		case tcell.KeyEsc:
+			emit(events.HideView{})
+		}
+	})
+
+	footer := tview.NewTextView()
+	footer.SetDynamicColors(true).
+		SetTextAlign(tview.AlignCenter).
+		SetText("Enter: save" + components.Divider + "Esc: cancel" + components.Divider + "empty alias clears")
+	footer.SetTextColor(tview.Styles.SecondaryTextColor)
+	footer.SetBackgroundColor(tview.Styles.PrimitiveBackgroundColor)
+
+	content := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(input, 3, 0, true).
+		AddItem(footer, 1, 0, false)
+
+	root := tview.NewFlex().SetDirection(tview.FlexRow).
+		AddItem(nil, 0, 1, false).
+		AddItem(tview.NewFlex().SetDirection(tview.FlexColumn).
+			AddItem(nil, 0, 1, false).
+			AddItem(content, 60, 0, true).
+			AddItem(nil, 0, 1, false), 0, 1, true).
+		AddItem(nil, 0, 1, false)
+
+	v := &AliasModalView{
+		Flex:   root,
+		input:  input,
+		footer: footer,
+	}
+
+	theme.RegisterPrimitive(content)
+	theme.RegisterPrimitive(input)
+	theme.RegisterPrimitive(footer)
+
+	return v
+}
+
+func (v *AliasModalView) FocusTarget() tview.Primitive { return v.input }
+
+// Prepare resets the editor for a specific device and alias.
+func (v *AliasModalView) Prepare(deviceMAC, alias string) {
+	v.currentMAC = deviceMAC
+	v.input.SetText(alias)
+}
+
+func (v *AliasModalView) Render(s state.ReadOnly) {
+	device, ok := s.Selected()
+	if !ok {
+		v.input.SetTitle(" Device Alias ")
+		return
+	}
+
+	title := " Device Alias "
+	if mac := device.MAC(); mac != "" {
+		title = fmt.Sprintf(" Device Alias (%s) ", mac)
+	}
+	v.input.SetTitle(title)
+
+	if mac := device.MAC(); mac != "" && mac != v.currentMAC {
+		v.currentMAC = mac
+		v.input.SetText(s.AliasFor(device))
+	}
+}

--- a/internal/ui/views/alias_modal.go
+++ b/internal/ui/views/alias_modal.go
@@ -16,9 +16,8 @@ var _ View = &AliasModalView{}
 // AliasModalView is a modal overlay for editing the selected device alias.
 type AliasModalView struct {
 	*tview.Flex
-	input      *tview.InputField
-	footer     *tview.TextView
-	currentMAC string
+	input  *tview.InputField
+	footer *tview.TextView
 }
 
 func NewAliasModalView(emit func(events.Event)) *AliasModalView {
@@ -26,6 +25,9 @@ func NewAliasModalView(emit func(events.Event)) *AliasModalView {
 		SetLabel("Alias: ").
 		SetFieldWidth(36)
 	input.SetBorder(true).SetTitle(" Device Alias ")
+	input.SetChangedFunc(func(text string) {
+		emit(events.AliasDraftChanged{Alias: text})
+	})
 	input.SetDoneFunc(func(key tcell.Key) {
 		switch key {
 		case tcell.KeyEnter:
@@ -69,12 +71,6 @@ func NewAliasModalView(emit func(events.Event)) *AliasModalView {
 
 func (v *AliasModalView) FocusTarget() tview.Primitive { return v.input }
 
-// Prepare resets the editor for a specific device and alias.
-func (v *AliasModalView) Prepare(deviceMAC, alias string) {
-	v.currentMAC = deviceMAC
-	v.input.SetText(alias)
-}
-
 func (v *AliasModalView) Render(s state.ReadOnly) {
 	device, ok := s.Selected()
 	if !ok {
@@ -87,9 +83,7 @@ func (v *AliasModalView) Render(s state.ReadOnly) {
 		title = fmt.Sprintf(" Device Alias (%s) ", mac)
 	}
 	v.input.SetTitle(title)
-
-	if mac := device.MAC(); mac != "" && mac != v.currentMAC {
-		v.currentMAC = mac
-		v.input.SetText(s.AliasFor(device))
+	if draft := s.AliasEditorDraft(); v.input.GetText() != draft {
+		v.input.SetText(draft)
 	}
 }

--- a/internal/ui/views/dashboard.go
+++ b/internal/ui/views/dashboard.go
@@ -39,6 +39,7 @@ func NewDashboardView(emit func(events.Event), queue func(f func())) *DashboardV
 			"Enter: details" + components.Divider +
 			"y: copy" + components.Divider +
 			"Ctrl+I: interface" + components.Divider +
+			"Ctrl+R: reset aliases" + components.Divider +
 			"Ctrl+T: theme" + components.Divider +
 			"q: quit",
 	)

--- a/internal/ui/views/detail.go
+++ b/internal/ui/views/detail.go
@@ -37,7 +37,7 @@ func NewDetailView(emit func(events.Event), queue func(f func())) *DetailView {
 		SetTitle(" Details ")
 
 	statusBar := components.NewStatusBar()
-	statusBar.SetHelp("q: Quit" + components.Divider + "Esc: Back" + components.Divider + "y/Y: Copy IP/MAC" + components.Divider + "p: Port Scan")
+	statusBar.SetHelp("q: Quit" + components.Divider + "Esc: Back" + components.Divider + "y/Y: Copy IP/MAC" + components.Divider + "e: Edit Alias" + components.Divider + "D: Clear Alias" + components.Divider + "Ctrl+R: Reset Aliases" + components.Divider + "p: Port Scan")
 
 	main.AddItem(header, 1, 0, false)
 	main.AddItem(info, 0, 1, true)
@@ -71,6 +71,12 @@ func handleInput(p *DetailView) func(ev *tcell.EventKey) *tcell.EventKey {
 			return nil
 		case ev.Rune() == 'p':
 			p.emit(events.NavigateTo{Route: routes.RoutePortScan, Overlay: true})
+			return nil
+		case ev.Rune() == 'e':
+			p.emit(events.AliasEditRequested{})
+			return nil
+		case ev.Rune() == 'D':
+			p.emit(events.AliasCleared{})
 			return nil
 		case ev.Rune() == 'y':
 			p.emit(events.CopyIP{})
@@ -141,8 +147,17 @@ func (d *DetailView) Render(s state.ReadOnly) {
 		return t.Format("2006-01-02 15:04:05")
 	}
 
+	name := s.PreferredNameFor(device)
+	alias := s.AliasFor(device)
+
 	writeLine("IP", device.IP().String())
-	writeLine("Display Name", device.DisplayName())
+	writeLine("Name", name)
+	if alias != "" {
+		writeLine("Alias", alias)
+		if detectedName := device.DisplayName(); detectedName != "" {
+			writeLine("Detected Name", detectedName)
+		}
+	}
 	writeLine("MAC", device.MAC())
 	writeLine("Manufacturer", device.Manufacturer())
 	if iface := device.InterfaceName(); iface != "" {

--- a/internal/ui/views/reset_aliases_modal.go
+++ b/internal/ui/views/reset_aliases_modal.go
@@ -1,0 +1,48 @@
+package views
+
+import (
+	"github.com/gdamore/tcell/v2"
+	"github.com/ramonvermeulen/whosthere/internal/core/state"
+	"github.com/ramonvermeulen/whosthere/internal/ui/events"
+	"github.com/ramonvermeulen/whosthere/internal/ui/theme"
+	"github.com/rivo/tview"
+)
+
+var _ View = &ResetAliasesModalView{}
+
+// ResetAliasesModalView confirms clearing all persisted aliases.
+type ResetAliasesModalView struct {
+	*tview.Modal
+}
+
+func NewResetAliasesModalView(emit func(events.Event)) *ResetAliasesModalView {
+	modal := tview.NewModal().
+		SetText("").
+		AddButtons([]string{"Reset Aliases", "Cancel"}).
+		SetDoneFunc(func(buttonIndex int, _ string) {
+			if buttonIndex == 0 {
+				emit(events.AliasesResetConfirmed{})
+				return
+			}
+			emit(events.HideView{})
+		})
+
+	modal.SetInputCapture(func(event *tcell.EventKey) *tcell.EventKey {
+		if event.Key() == tcell.KeyEsc {
+			emit(events.HideView{})
+			return nil
+		}
+		return event
+	})
+
+	theme.RegisterPrimitive(modal)
+
+	return &ResetAliasesModalView{Modal: modal}
+}
+
+func (v *ResetAliasesModalView) FocusTarget() tview.Primitive { return v.Modal }
+
+func (v *ResetAliasesModalView) Render(state.ReadOnly) {
+	v.SetTitle(" Reset Aliases ")
+	v.SetText("Delete all saved device aliases from local storage?\n\nDetected names from scanners will remain visible.\nThis action cannot be undone.")
+}


### PR DESCRIPTION
Closes: https://github.com/ramonvermeulen/whosthere/issues/45

## Summary
This PR introduces a persistent storage layer using [bbolt](https://github.com/etcd-io/bbolt) to store displayName aliases for devices, using the device's MAC address as the unique identifier.

## Why bbolt over a simple file (e.g., YAML)?
While a YAML file could have worked for simple key-value storage, bbolt was chosen because it lays the groundwork for a future full persistent mode with historical data tracking (see #74). I think the embedded key-value store will scale better as we add more data types and querying capabilities compared to yaml or another config-like storage format.

## New Features
This PR adds TUI enhancements to manage device aliases:

- New keybindings for editing and resetting display names
- Modal dialogs to guide users through:
  - Editing a device's display name
  - Resetting an individual device's display name
  - Resetting the entire bbolt database

## Scope Note
This feature is currently implemented **only for the TUI application**. CLI and daemon modes remain unchanged.