### PR TITLE
feat(header): show current active network interface in the header + FAQ link

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"os/signal"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -26,6 +28,7 @@ import (
 
 const (
 	refreshInterval = 1 * time.Second
+	askQuestionURL  = "https://github.com/ramonvermeulen/whosthere/discussions/new/choose"
 )
 
 // App represents the main TUI application.
@@ -369,6 +372,10 @@ func (a *App) handleEvents() {
 					a.logger.Warn("failed to copy to clipboard", "error", err)
 				}
 			}
+		case events.AskQuestionRequested:
+			if err := openURL(askQuestionURL); err != nil {
+				a.logger.Warn("failed to open GitHub Discussions", "url", askQuestionURL, "error", err)
+			}
 		case events.InterfaceSelected:
 			go a.switchInterface(event.Name)
 		}
@@ -440,4 +447,19 @@ func (a *App) switchInterface(name string) {
 
 	a.engine.Start(context.Background())
 	go a.handleEngineEvents(ctx, engine, gen)
+}
+
+func openURL(target string) error {
+	var cmd *exec.Cmd
+
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", target)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", target)
+	default:
+		cmd = exec.Command("xdg-open", target)
+	}
+
+	return cmd.Start()
 }

--- a/internal/ui/components/header.go
+++ b/internal/ui/components/header.go
@@ -88,30 +88,34 @@ func (h *Header) Render(s state.ReadOnly) {
 	h.link.SetText(linkText)
 }
 
-func renderHeaderMeta(s state.ReadOnly) (string, string) {
+func renderHeaderMeta(s state.ReadOnly) (interfaceText string, linkText string) {
 	if s == nil {
-		return "", askQuestionLabel
+		linkText = askQuestionLabel
+		return
 	}
 
-	interfaceText := strings.TrimSpace(s.CurrentInterface())
+	interfaceText = strings.TrimSpace(s.CurrentInterface())
 	if interfaceText != "" {
 		interfaceText = utils.Truncate(interfaceText, 18)
 		interfaceText = interfaceLabelPrefix + interfaceText
 	}
 
 	if s.NoColor() {
+		linkText = askQuestionLabel
 		if interfaceText == "" {
-			return "", askQuestionLabel
+			return
 		}
-		return interfaceText + " " + Divider, askQuestionLabel
+		interfaceText = interfaceText + " " + Divider
+		return
 	}
 
 	linkColor := utils.ColorToHexTag(tview.Styles.PrimaryTextColor)
-	linkText := "[" + linkColor + "::bu]" + askQuestionLabel + "[-:-:-]"
+	linkText = "[" + linkColor + "::bu]" + askQuestionLabel + "[-:-:-]"
 	if interfaceText == "" {
-		return "", linkText
+		return
 	}
 
 	interfaceColor := utils.ColorToHexTag(tview.Styles.SecondaryTextColor)
-	return "[" + interfaceColor + "::]" + interfaceText + "[-:-:-] " + Divider, linkText
+	interfaceText = "[" + interfaceColor + "::]" + interfaceText + "[-:-:-] " + Divider
+	return
 }

--- a/internal/ui/components/header.go
+++ b/internal/ui/components/header.go
@@ -1,36 +1,117 @@
 package components
 
 import (
+	"strings"
+
+	"github.com/gdamore/tcell/v2"
 	"github.com/ramonvermeulen/whosthere/internal/core/state"
+	"github.com/ramonvermeulen/whosthere/internal/ui/events"
 	"github.com/ramonvermeulen/whosthere/internal/ui/theme"
+	"github.com/ramonvermeulen/whosthere/internal/ui/utils"
 	"github.com/rivo/tview"
+)
+
+const (
+	baseTitle            = "whosthere"
+	headerInterfaceWidth = 24
+	askQuestionLabel     = "Ask Question"
+	headerLinkWidth      = len(askQuestionLabel)
+	interfaceLabelPrefix = "interface: "
 )
 
 var _ UIComponent = &Header{}
 
-// Header is a simple reusable header bar for pages.
-// It renders the app title and, optionally, a version string.
+// Header renders the page title and right-aligned metadata/actions.
 type Header struct {
-	*tview.TextView
+	*tview.Flex
+	title          *tview.TextView
+	interfaceLabel *tview.TextView
+	link           *tview.TextView
+	rightSide      *tview.Flex
 }
 
-// NewHeader creates a header with a fixed base title.
-func NewHeader() *Header {
-	const baseTitle = "whosthere"
-	tv := tview.NewTextView().
-		SetText(baseTitle).
-		SetTextAlign(tview.AlignCenter)
+// NewHeader creates a reusable page header.
+func NewHeader(emit func(events.Event)) *Header {
+	title := tview.NewTextView().
+		SetTextAlign(tview.AlignLeft)
+	interfaceLabel := tview.NewTextView().
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignRight)
+	link := tview.NewTextView().
+		SetDynamicColors(true).
+		SetTextAlign(tview.AlignRight)
 
-	theme.RegisterPrimitive(tv)
-	return &Header{TextView: tv}
+	if emit != nil {
+		link.SetMouseCapture(func(action tview.MouseAction, event *tcell.EventMouse) (tview.MouseAction, *tcell.EventMouse) {
+			if action == tview.MouseLeftClick {
+				emit(events.AskQuestionRequested{})
+				return action, nil
+			}
+			return action, event
+		})
+	}
+
+	rightSide := tview.NewFlex().
+		SetDirection(tview.FlexColumn).
+		AddItem(interfaceLabel, headerInterfaceWidth, 0, false).
+		AddItem(link, headerLinkWidth, 0, false)
+
+	row := tview.NewFlex().
+		SetDirection(tview.FlexColumn).
+		AddItem(title, 0, 1, false).
+		AddItem(rightSide, headerInterfaceWidth+headerLinkWidth, 0, false)
+
+	theme.RegisterPrimitive(title)
+	theme.RegisterPrimitive(interfaceLabel)
+	theme.RegisterPrimitive(link)
+	theme.RegisterPrimitive(rightSide)
+	theme.RegisterPrimitive(row)
+
+	return &Header{
+		Flex:           row,
+		title:          title,
+		interfaceLabel: interfaceLabel,
+		link:           link,
+		rightSide:      rightSide,
+	}
 }
 
 // Render implements UIComponent.
 func (h *Header) Render(s state.ReadOnly) {
-	const baseTitle = "whosthere"
 	text := baseTitle
 	if version := s.Version(); version != "" {
 		text = baseTitle + " - v" + version
 	}
-	h.SetText(text)
+	h.title.SetText(text)
+	interfaceText, linkText := renderHeaderMeta(s)
+	h.interfaceLabel.SetText(interfaceText)
+	h.link.SetText(linkText)
+}
+
+func renderHeaderMeta(s state.ReadOnly) (string, string) {
+	if s == nil {
+		return "", askQuestionLabel
+	}
+
+	interfaceText := strings.TrimSpace(s.CurrentInterface())
+	if interfaceText != "" {
+		interfaceText = utils.Truncate(interfaceText, 18)
+		interfaceText = interfaceLabelPrefix + interfaceText
+	}
+
+	if s.NoColor() {
+		if interfaceText == "" {
+			return "", askQuestionLabel
+		}
+		return interfaceText + " " + Divider, askQuestionLabel
+	}
+
+	linkColor := utils.ColorToHexTag(tview.Styles.PrimaryTextColor)
+	linkText := "[" + linkColor + "::bu]" + askQuestionLabel + "[-:-:-]"
+	if interfaceText == "" {
+		return "", linkText
+	}
+
+	interfaceColor := utils.ColorToHexTag(tview.Styles.SecondaryTextColor)
+	return "[" + interfaceColor + "::]" + interfaceText + "[-:-:-] " + Divider, linkText
 }

--- a/internal/ui/components/header.go
+++ b/internal/ui/components/header.go
@@ -88,7 +88,7 @@ func (h *Header) Render(s state.ReadOnly) {
 	h.link.SetText(linkText)
 }
 
-func renderHeaderMeta(s state.ReadOnly) (interfaceText string, linkText string) {
+func renderHeaderMeta(s state.ReadOnly) (interfaceText, linkText string) {
 	if s == nil {
 		linkText = askQuestionLabel
 		return

--- a/internal/ui/components/header_test.go
+++ b/internal/ui/components/header_test.go
@@ -1,0 +1,51 @@
+package components
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ramonvermeulen/whosthere/internal/core/config"
+	"github.com/ramonvermeulen/whosthere/internal/core/state"
+)
+
+func TestHeaderRenderIncludesVersionInterfaceAndAskQuestion(t *testing.T) {
+	cfg := config.DefaultConfig()
+	st := state.NewAppState(cfg, "1.2.3")
+	st.SetCurrentInterface("en0")
+
+	header := NewHeader(nil)
+	header.Render(st.ReadOnly())
+
+	if got := header.title.GetText(false); got != "whosthere - v1.2.3" {
+		t.Fatalf("unexpected header title: %q", got)
+	}
+
+	interfaceLabel := header.interfaceLabel.GetText(false)
+	if !strings.Contains(interfaceLabel, "interface: en0") {
+		t.Fatalf("expected interface in header label view, got %q", interfaceLabel)
+	}
+
+	link := header.link.GetText(false)
+	if !strings.Contains(link, "Ask Question") {
+		t.Fatalf("expected ask question label in header link view, got %q", link)
+	}
+}
+
+func TestRenderHeaderMetaNoColor(t *testing.T) {
+	cfg := config.DefaultConfig()
+	cfg.Theme.NoColor = true
+
+	st := state.NewAppState(cfg, "1.2.3")
+	st.SetCurrentInterface("very-long-interface-name")
+
+	interfaceLabel, link := renderHeaderMeta(st.ReadOnly())
+	if !strings.Contains(interfaceLabel, "interface:") || !strings.Contains(interfaceLabel, Divider) {
+		t.Fatalf("expected plain interface label, got %q", interfaceLabel)
+	}
+	if !strings.Contains(link, "Ask Question") {
+		t.Fatalf("expected plain ask question label, got %q", link)
+	}
+	if strings.Contains(interfaceLabel, "#") || strings.Contains(link, "#") {
+		t.Fatalf("expected plain text without color tags, got interface=%q link=%q", interfaceLabel, link)
+	}
+}

--- a/internal/ui/events/events.go
+++ b/internal/ui/events/events.go
@@ -68,8 +68,10 @@ type CopyMac struct {
 	MAC string
 }
 
+// AskQuestionRequested opens the GitHub Discussions page for asking a question.
+type AskQuestionRequested struct{}
+
 // InterfaceSelected is emitted when a network interface is selected.
 type InterfaceSelected struct {
 	Name string
 }
-

--- a/internal/ui/views/dashboard.go
+++ b/internal/ui/views/dashboard.go
@@ -25,7 +25,7 @@ type DashboardView struct {
 }
 
 func NewDashboardView(emit func(events.Event), queue func(f func())) *DashboardView {
-	header := components.NewHeader()
+	header := components.NewHeader(emit)
 	t := components.NewDeviceTable(emit)
 
 	main := tview.NewFlex().SetDirection(tview.FlexRow)
@@ -38,6 +38,7 @@ func NewDashboardView(emit func(events.Event), queue func(f func())) *DashboardV
 		"j/k: up/down" + components.Divider +
 			"Enter: details" + components.Divider +
 			"y: copy" + components.Divider +
+			"?: ask" + components.Divider +
 			"Ctrl+I: interface" + components.Divider +
 			"Ctrl+T: theme" + components.Divider +
 			"q: quit",
@@ -58,7 +59,13 @@ func NewDashboardView(emit func(events.Event), queue func(f func())) *DashboardV
 	theme.RegisterPrimitive(d)
 
 	d.updateFooter(false)
-	t.SetInputCapture(func(ev *tcell.EventKey) *tcell.EventKey { return t.HandleInput(ev) })
+	t.SetInputCapture(func(ev *tcell.EventKey) *tcell.EventKey {
+		if ev != nil && ev.Rune() == '?' {
+			emit(events.AskQuestionRequested{})
+			return nil
+		}
+		return t.HandleInput(ev)
+	})
 	t.SetSelectedFunc(func(row, col int) {
 		ip := t.SelectedIP()
 		if ip == "" {

--- a/internal/ui/views/dashboard.go
+++ b/internal/ui/views/dashboard.go
@@ -38,7 +38,6 @@ func NewDashboardView(emit func(events.Event), queue func(f func())) *DashboardV
 		"j/k: up/down" + components.Divider +
 			"Enter: details" + components.Divider +
 			"y: copy" + components.Divider +
-			"?: ask" + components.Divider +
 			"Ctrl+I: interface" + components.Divider +
 			"Ctrl+R: reset aliases" + components.Divider +
 			"Ctrl+T: theme" + components.Divider +
@@ -61,10 +60,6 @@ func NewDashboardView(emit func(events.Event), queue func(f func())) *DashboardV
 
 	d.updateFooter(false)
 	t.SetInputCapture(func(ev *tcell.EventKey) *tcell.EventKey {
-		if ev != nil && ev.Rune() == '?' {
-			emit(events.AskQuestionRequested{})
-			return nil
-		}
 		return t.HandleInput(ev)
 	})
 	t.SetSelectedFunc(func(row, col int) {

--- a/internal/ui/views/detail.go
+++ b/internal/ui/views/detail.go
@@ -37,7 +37,7 @@ func NewDetailView(emit func(events.Event), queue func(f func())) *DetailView {
 		SetTitle(" Details ")
 
 	statusBar := components.NewStatusBar()
-	statusBar.SetHelp("q: Quit" + components.Divider + "Esc: Back" + components.Divider + "y/Y: Copy IP/MAC" + components.Divider + "e: Edit Alias" + components.Divider + "D: Clear Alias" + components.Divider + "Ctrl+R: Reset Aliases" + components.Divider + "p: Port Scan" + "?: ask")
+	statusBar.SetHelp("q: Quit" + components.Divider + "Esc: Back" + components.Divider + "y/Y: Copy IP/MAC" + components.Divider + "e: Edit Alias" + components.Divider + "D: Clear Alias" + components.Divider + "Ctrl+R: Reset Aliases" + components.Divider + "p: Port Scan")
 
 	main.AddItem(header, 1, 0, false)
 	main.AddItem(info, 0, 1, true)
@@ -83,9 +83,6 @@ func handleInput(p *DetailView) func(ev *tcell.EventKey) *tcell.EventKey {
 			return nil
 		case ev.Rune() == 'Y':
 			p.emit(events.CopyMac{})
-			return nil
-		case ev.Rune() == '?':
-			p.emit(events.AskQuestionRequested{})
 			return nil
 		default:
 			return ev

--- a/internal/ui/views/detail.go
+++ b/internal/ui/views/detail.go
@@ -30,14 +30,14 @@ type DetailView struct {
 
 func NewDetailView(emit func(events.Event), queue func(f func())) *DetailView {
 	main := tview.NewFlex().SetDirection(tview.FlexRow)
-	header := components.NewHeader()
+	header := components.NewHeader(emit)
 
 	info := tview.NewTextView().SetDynamicColors(true).SetWrap(true)
 	info.SetBorder(true).
 		SetTitle(" Details ")
 
 	statusBar := components.NewStatusBar()
-	statusBar.SetHelp("q: Quit" + components.Divider + "Esc: Back" + components.Divider + "y/Y: Copy IP/MAC" + components.Divider + "p: Port Scan")
+	statusBar.SetHelp("q: Quit" + components.Divider + "Esc: Back" + components.Divider + "y/Y: Copy IP/MAC" + components.Divider + "p: Port Scan" + components.Divider + "?: ask")
 
 	main.AddItem(header, 1, 0, false)
 	main.AddItem(info, 0, 1, true)
@@ -77,6 +77,9 @@ func handleInput(p *DetailView) func(ev *tcell.EventKey) *tcell.EventKey {
 			return nil
 		case ev.Rune() == 'Y':
 			p.emit(events.CopyMac{})
+			return nil
+		case ev.Rune() == '?':
+			p.emit(events.AskQuestionRequested{})
 			return nil
 		default:
 			return ev


### PR DESCRIPTION
Shows the current active network interface in the header of the TUI together with a link to the FAQ (Github discussions).