### PR TITLE
feat(ux): improve bottom status bar + highlight currently selected device + color for last seen

### DIFF
--- a/internal/ui/components/device_table.go
+++ b/internal/ui/components/device_table.go
@@ -17,6 +17,11 @@ import (
 
 var _ UIComponent = &DeviceTable{}
 
+const (
+	recentLastSeenThreshold = time.Minute
+	staleLastSeenThreshold  = time.Minute
+)
+
 // DeviceTable wraps a tview.Table for displaying discovered devices.
 type DeviceTable struct {
 	*tview.Table
@@ -170,6 +175,7 @@ func (dt *DeviceTable) applySearch(pattern string) {
 func (dt *DeviceTable) Render(st state.ReadOnly) {
 	dt.state = st
 	dt.devices = st.DevicesSnapshot()
+	dt.applyThemeStyles()
 	_ = dt.SetFilter(st.FilterPattern())
 }
 
@@ -225,6 +231,7 @@ func (dt *DeviceTable) moveSelection(delta int) {
 
 type tableRow struct {
 	ip, hostname, mac, manufacturer, lastSeen, alias, detectedName string
+	lastSeenAge                                                    time.Duration
 }
 
 func (dt *DeviceTable) buildRows() []tableRow {
@@ -243,6 +250,7 @@ func (dt *DeviceTable) buildRows() []tableRow {
 			mac:          d.MAC(),
 			manufacturer: d.Manufacturer(),
 			lastSeen:     utils.FmtDuration(time.Since(d.LastSeen())),
+			lastSeenAge:  time.Since(d.LastSeen()),
 			alias:        alias,
 			detectedName: d.DisplayName(),
 		}
@@ -290,7 +298,9 @@ func (dt *DeviceTable) refresh() {
 		dt.SetCell(r, 1, tview.NewTableCell(hostText).SetExpansion(1))
 		dt.SetCell(r, 2, tview.NewTableCell(macText).SetExpansion(1))
 		dt.SetCell(r, 3, tview.NewTableCell(manuText).SetExpansion(1))
-		dt.SetCell(r, 4, tview.NewTableCell(seenText).SetExpansion(1))
+		dt.SetCell(r, 4, tview.NewTableCell(seenText).
+			SetTextColor(lastSeenColor(rowData.lastSeenAge, dt.noColor())).
+			SetExpansion(1))
 	}
 	// Restore selection if possible, otherwise select first.
 	if dt.GetRowCount() > 1 {
@@ -320,4 +330,39 @@ func (dt *DeviceTable) rowMatches(r *tableRow) bool {
 		dt.filterRE.MatchString(r.alias) ||
 		dt.filterRE.MatchString(r.detectedName) ||
 		dt.filterRE.MatchString(r.lastSeen)
+}
+
+func (dt *DeviceTable) applyThemeStyles() {
+	if dt == nil || dt.Table == nil {
+		return
+	}
+
+	if dt.noColor() {
+		dt.SetSelectedStyle(tcell.StyleDefault.Reverse(true))
+		return
+	}
+
+	dt.SetSelectedStyle(tcell.StyleDefault.
+		Foreground(tview.Styles.InverseTextColor).
+		Background(tview.Styles.SecondaryTextColor).
+		Attributes(tcell.AttrBold))
+}
+
+func (dt *DeviceTable) noColor() bool {
+	return dt.state != nil && dt.state.NoColor()
+}
+
+func lastSeenColor(age time.Duration, noColor bool) tcell.Color {
+	if noColor {
+		return tview.Styles.PrimaryTextColor
+	}
+
+	switch {
+	case age <= recentLastSeenThreshold:
+		return tview.Styles.ContrastSecondaryTextColor
+	case age >= staleLastSeenThreshold:
+		return tview.Styles.TertiaryTextColor
+	default:
+		return tview.Styles.PrimaryTextColor
+	}
 }

--- a/internal/ui/components/device_table_test.go
+++ b/internal/ui/components/device_table_test.go
@@ -3,10 +3,13 @@ package components
 import (
 	"net"
 	"testing"
+	"time"
 
+	"github.com/gdamore/tcell/v2"
 	"github.com/ramonvermeulen/whosthere/internal/core/config"
 	"github.com/ramonvermeulen/whosthere/internal/core/state"
 	"github.com/ramonvermeulen/whosthere/pkg/discovery"
+	"github.com/rivo/tview"
 )
 
 func TestDeviceTableRenderUsesPreferredName(t *testing.T) {
@@ -52,5 +55,57 @@ func TestDeviceTableFilterMatchesAliasAndDetectedName(t *testing.T) {
 	}
 	if table.GetRowCount() != 2 {
 		t.Fatalf("row count after detected-name filter = %d, want 2", table.GetRowCount())
+	}
+}
+
+func TestLastSeenColorUsesFreshnessBuckets(t *testing.T) {
+	t.Parallel()
+
+	if got := lastSeenColor(20*time.Second, false); got != tview.Styles.ContrastSecondaryTextColor {
+		t.Fatalf("fresh last-seen color = %v, want %v", got, tview.Styles.ContrastSecondaryTextColor)
+	}
+
+	if got := lastSeenColor(2*time.Minute, false); got != tview.Styles.TertiaryTextColor {
+		t.Fatalf("normal last-seen color = %v, want %v", got, tview.Styles.TertiaryTextColor)
+	}
+
+	if got := lastSeenColor(10*time.Minute, false); got != tview.Styles.TertiaryTextColor {
+		t.Fatalf("stale last-seen color = %v, want %v", got, tview.Styles.TertiaryTextColor)
+	}
+
+	if got := lastSeenColor(20*time.Second, true); got != tview.Styles.PrimaryTextColor {
+		t.Fatalf("no-color last-seen color = %v, want %v", got, tview.Styles.PrimaryTextColor)
+	}
+}
+
+func TestDeviceTableSelectedRowUsesThemeAccentStyle(t *testing.T) {
+	device := discovery.NewDevice(net.ParseIP("192.168.1.10"))
+
+	table := NewDeviceTable(nil)
+	table.devices = []*discovery.Device{device}
+	table.applyThemeStyles()
+	table.refresh()
+	table.SetRect(0, 0, 80, 10)
+
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatalf("init screen: %v", err)
+	}
+	defer screen.Fini()
+
+	table.Draw(screen)
+
+	x, y, _ := table.GetCell(1, 0).GetLastPosition()
+	_, _, style, _ := screen.GetContent(x, y)
+	foreground, background, attrs := style.Decompose()
+
+	if foreground != tview.Styles.InverseTextColor {
+		t.Fatalf("selected row foreground = %v, want %v", foreground, tview.Styles.InverseTextColor)
+	}
+	if background != tview.Styles.SecondaryTextColor {
+		t.Fatalf("selected row background = %v, want %v", background, tview.Styles.SecondaryTextColor)
+	}
+	if attrs&tcell.AttrBold == 0 {
+		t.Fatalf("selected row attrs = %v, want bold", attrs)
 	}
 }

--- a/internal/ui/components/device_table_test.go
+++ b/internal/ui/components/device_table_test.go
@@ -96,7 +96,7 @@ func TestDeviceTableSelectedRowUsesThemeAccentStyle(t *testing.T) {
 	table.Draw(screen)
 
 	x, y, _ := table.GetCell(1, 0).GetLastPosition()
-	_, _, style, _ := screen.GetContent(x, y)
+	_, style, _ := screen.Get(x, y)
 	foreground, background, attrs := style.Decompose()
 
 	if foreground != tview.Styles.InverseTextColor {

--- a/internal/ui/components/spinner.go
+++ b/internal/ui/components/spinner.go
@@ -43,7 +43,7 @@ func (s *Spinner) setText(text string) {
 	s.mu.Lock()
 	s.text = text
 	s.mu.Unlock()
-	s.TextView.SetText(text)
+	s.SetText(text)
 }
 
 func formatSpinnerText(frame, suffix string) string {

--- a/internal/ui/components/spinner.go
+++ b/internal/ui/components/spinner.go
@@ -1,6 +1,7 @@
 package components
 
 import (
+	"strings"
 	"sync"
 	"time"
 
@@ -17,6 +18,7 @@ type Spinner struct {
 	stop    chan struct{}
 	running bool
 	suffix  string
+	text    string
 }
 
 func NewSpinner() *Spinner {
@@ -29,6 +31,30 @@ func (s *Spinner) SetSuffix(suf string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.suffix = suf
+}
+
+func (s *Spinner) Text() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.text
+}
+
+func (s *Spinner) setText(text string) {
+	s.mu.Lock()
+	s.text = text
+	s.mu.Unlock()
+	s.TextView.SetText(text)
+}
+
+func formatSpinnerText(frame, suffix string) string {
+	label := strings.TrimSpace(suffix)
+	if label == "" {
+		return frame
+	}
+	if frame == "" {
+		return label
+	}
+	return frame + " " + label
 }
 
 func (s *Spinner) Start(queue func(f func())) {
@@ -56,7 +82,7 @@ func (s *Spinner) Start(queue func(f func())) {
 				s.mu.Lock()
 				s.running = false
 				s.mu.Unlock()
-				queue(func() { s.SetText("") })
+				queue(func() { s.setText("") })
 				return
 			case <-time.After(interval):
 				ch := string(frames[idx%len(frames)])
@@ -64,7 +90,7 @@ func (s *Spinner) Start(queue func(f func())) {
 				s.mu.Lock()
 				suffix := s.suffix
 				s.mu.Unlock()
-				queue(func() { s.SetText(ch + suffix) })
+				queue(func() { s.setText(formatSpinnerText(ch, suffix)) })
 			}
 		}
 	}()
@@ -75,7 +101,7 @@ func (s *Spinner) Stop(queue func(f func())) {
 	case s.stop <- struct{}{}:
 	default:
 	}
-	queue(func() { s.SetText("") })
+	queue(func() { s.setText("") })
 	s.mu.Lock()
 	s.running = false
 	s.mu.Unlock()

--- a/internal/ui/components/status_bar.go
+++ b/internal/ui/components/status_bar.go
@@ -1,71 +1,130 @@
 package components
 
 import (
+	"strings"
+
 	"github.com/gdamore/tcell/v2"
 	"github.com/ramonvermeulen/whosthere/internal/core/state"
 	"github.com/ramonvermeulen/whosthere/internal/ui/theme"
 	"github.com/rivo/tview"
 )
 
+const statusBarGap = 1
+
 var _ UIComponent = &StatusBar{}
 
-// StatusBar combines a Spinner with a right-aligned help text into a single flex row.
+// StatusBar renders spinner/status text followed by the footer help line.
 type StatusBar struct {
-	*tview.Flex
-	spinner  *Spinner
-	help     *tview.TextView
-	helpText string
+	*tview.Box
+	spinner      *Spinner
+	helpText     string
+	displayText  string
+	displayColor tcell.Color
+	noColor      bool
 }
 
 func NewStatusBar() *StatusBar {
-	sp := NewSpinner()
-	help := tview.NewTextView().
-		SetTextAlign(tview.AlignRight)
-	row := tview.NewFlex().
-		SetDirection(tview.FlexColumn).
-		AddItem(sp, 0, 1, false).
-		AddItem(help, 0, 2, false)
-
-	theme.RegisterPrimitive(help)
-	theme.RegisterPrimitive(row)
-
-	return &StatusBar{
-		Flex:    row,
-		spinner: sp,
-		help:    help,
+	sb := &StatusBar{
+		Box:          tview.NewBox(),
+		spinner:      NewSpinner(),
+		displayColor: tview.Styles.PrimaryTextColor,
 	}
+
+	theme.RegisterPrimitive(sb)
+	return sb
 }
 
 func (s *StatusBar) Spinner() *Spinner { return s.spinner }
 
 func (s *StatusBar) SetHelp(text string) {
-	if s == nil || s.help == nil {
+	if s == nil {
 		return
 	}
 	s.helpText = text
-	s.help.SetText(text)
+}
+
+// Draw implements tview.Primitive.
+func (s *StatusBar) Draw(screen tcell.Screen) {
+	if s == nil || s.Box == nil {
+		return
+	}
+
+	s.Box.Draw(screen)
+	x, y, width, height := s.GetInnerRect()
+	if width <= 0 || height <= 0 {
+		return
+	}
+
+	spinnerText := s.spinner.Text()
+	spinnerWidth := tview.TaggedStringWidth(spinnerText)
+	spinnerColor := tview.Styles.SecondaryTextColor
+	if s.noColor {
+		spinnerColor = tview.Styles.PrimaryTextColor
+	}
+
+	if spinnerText != "" {
+		tview.Print(screen, spinnerText, x, y, width, tview.AlignLeft, spinnerColor)
+	}
+
+	textX := x
+	textWidth := width
+	if spinnerText != "" {
+		textX += spinnerWidth + statusBarGap
+		textWidth -= spinnerWidth + statusBarGap
+	}
+	if textWidth <= 0 || s.displayText == "" {
+		return
+	}
+
+	tview.Print(screen, truncateToWidth(s.displayText, textWidth), textX, y, textWidth, tview.AlignLeft, s.displayColor)
 }
 
 // Render implements UIComponent.
 func (s *StatusBar) Render(st state.ReadOnly) {
-	if s == nil || s.help == nil {
+	if s == nil {
 		return
 	}
+
+	s.displayText = s.helpText
+	s.displayColor = tview.Styles.PrimaryTextColor
+	s.noColor = false
 
 	if st == nil {
-		s.help.SetText(s.helpText)
-		s.help.SetTextColor(tview.Styles.PrimaryTextColor)
 		return
 	}
 
+	s.noColor = st.NoColor()
 	if message := st.StatusMessage(); message != "" {
-		s.help.SetText(message)
-		s.help.SetTextColor(statusSeverityColor(st))
+		s.displayText = message
+		s.displayColor = statusSeverityColor(st)
 		return
 	}
 
-	s.help.SetText(s.helpText)
-	s.help.SetTextColor(tview.Styles.PrimaryTextColor)
+	s.displayText = s.helpText
+	s.displayColor = tview.Styles.PrimaryTextColor
+}
+
+func truncateToWidth(text string, width int) string {
+	if width <= 0 || text == "" {
+		return ""
+	}
+	if tview.TaggedStringWidth(text) <= width {
+		return text
+	}
+	if width == 1 {
+		return "…"
+	}
+
+	runes := []rune(text)
+	for len(runes) > 0 {
+		candidate := strings.TrimRight(string(runes), " ") + " …"
+		if tview.TaggedStringWidth(candidate) <= width {
+			return candidate
+		}
+		runes = runes[:len(runes)-1]
+	}
+
+	return "…"
 }
 
 func statusSeverityColor(st state.ReadOnly) tcell.Color {

--- a/internal/ui/components/status_bar_test.go
+++ b/internal/ui/components/status_bar_test.go
@@ -3,6 +3,7 @@ package components
 import (
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/ramonvermeulen/whosthere/internal/core/state"
@@ -66,7 +67,7 @@ func TestStatusBarUsesSecondaryColorForSpinner(t *testing.T) {
 	bar.SetRect(0, 0, 40, 1)
 	bar.Draw(screen)
 
-	_, _, style, _ := screen.GetContent(0, 0)
+	_, style, _ := screen.Get(0, 0)
 	foreground, _, _ := style.Decompose()
 	if foreground != tview.Styles.SecondaryTextColor {
 		t.Fatalf("expected spinner to use secondary text color, got %v", foreground)
@@ -87,11 +88,12 @@ func newSimulationScreen(t *testing.T) tcell.SimulationScreen {
 func readScreenLine(screen tcell.SimulationScreen, y, width int) string {
 	var b strings.Builder
 	for x := 0; x < width; x++ {
-		mainc, _, _, _ := screen.GetContent(x, y)
-		if mainc == 0 {
-			mainc = ' '
+		text, _, _ := screen.Get(x, y)
+		if text == "" {
+			text = " "
 		}
-		b.WriteRune(mainc)
+		r, _ := utf8.DecodeRuneInString(text)
+		b.WriteRune(r)
 	}
 	return b.String()
 }

--- a/internal/ui/components/status_bar_test.go
+++ b/internal/ui/components/status_bar_test.go
@@ -1,0 +1,97 @@
+package components
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/gdamore/tcell/v2"
+	"github.com/ramonvermeulen/whosthere/internal/core/state"
+	"github.com/rivo/tview"
+)
+
+func TestStatusBarDrawsHelpFromLeftWhenSpinnerHidden(t *testing.T) {
+	screen := newSimulationScreen(t)
+
+	bar := NewStatusBar()
+	bar.SetHelp("q: quit | Enter: details")
+	bar.Render(state.NewAppState(nil, ""))
+	bar.SetRect(0, 0, 40, 1)
+	bar.Draw(screen)
+
+	if got := strings.TrimRight(readScreenLine(screen, 0, 40), " "); !strings.HasPrefix(got, "q: quit | Enter: details") {
+		t.Fatalf("expected help text to start at the left edge, got %q", got)
+	}
+}
+
+func TestStatusBarPlacesHelpImmediatelyAfterSpinnerText(t *testing.T) {
+	screen := newSimulationScreen(t)
+
+	bar := NewStatusBar()
+	bar.SetHelp("q: quit")
+	bar.spinner.setText("x Discovering Devices")
+	bar.Render(state.NewAppState(nil, ""))
+	bar.SetRect(0, 0, 40, 1)
+	bar.Draw(screen)
+
+	got := strings.TrimRight(readScreenLine(screen, 0, 40), " ")
+	wantPrefix := "x Discovering Devices q: quit"
+	if !strings.HasPrefix(got, wantPrefix) {
+		t.Fatalf("expected spinner and help to share one left-aligned line, got %q", got)
+	}
+}
+
+func TestStatusBarTruncatesHelpWithEllipsisOnSmallWidths(t *testing.T) {
+	screen := newSimulationScreen(t)
+
+	bar := NewStatusBar()
+	bar.SetHelp("j/k: up/down | Enter: details | q: quit")
+	bar.spinner.setText("x Discovering Devices")
+	bar.Render(state.NewAppState(nil, ""))
+	bar.SetRect(0, 0, 30, 1)
+	bar.Draw(screen)
+
+	got := strings.TrimRight(readScreenLine(screen, 0, 30), " ")
+	if !strings.HasSuffix(got, " …") {
+		t.Fatalf("expected truncated help to end with ellipsis, got %q", got)
+	}
+}
+
+func TestStatusBarUsesSecondaryColorForSpinner(t *testing.T) {
+	screen := newSimulationScreen(t)
+
+	bar := NewStatusBar()
+	bar.SetHelp("q: quit")
+	bar.spinner.setText("x Discovering Devices")
+	bar.Render(nil)
+	bar.SetRect(0, 0, 40, 1)
+	bar.Draw(screen)
+
+	_, _, style, _ := screen.GetContent(0, 0)
+	foreground, _, _ := style.Decompose()
+	if foreground != tview.Styles.SecondaryTextColor {
+		t.Fatalf("expected spinner to use secondary text color, got %v", foreground)
+	}
+}
+
+func newSimulationScreen(t *testing.T) tcell.SimulationScreen {
+	t.Helper()
+
+	screen := tcell.NewSimulationScreen("UTF-8")
+	if err := screen.Init(); err != nil {
+		t.Fatalf("init screen: %v", err)
+	}
+	t.Cleanup(screen.Fini)
+	return screen
+}
+
+func readScreenLine(screen tcell.SimulationScreen, y, width int) string {
+	var b strings.Builder
+	for x := 0; x < width; x++ {
+		mainc, _, _, _ := screen.GetContent(x, y)
+		if mainc == 0 {
+			mainc = ' '
+		}
+		b.WriteRune(mainc)
+	}
+	return b.String()
+}

--- a/internal/ui/views/dashboard.go
+++ b/internal/ui/views/dashboard.go
@@ -33,7 +33,7 @@ func NewDashboardView(emit func(events.Event), queue func(f func())) *DashboardV
 	main.AddItem(t, 0, 1, true)
 
 	statusBar := components.NewStatusBar()
-	statusBar.Spinner().SetSuffix(" Discovering Devices...")
+	statusBar.Spinner().SetSuffix(" Discovering Devices")
 	statusBar.SetHelp(
 		"j/k: up/down" + components.Divider +
 			"Enter: details" + components.Divider +

--- a/internal/ui/views/detail.go
+++ b/internal/ui/views/detail.go
@@ -211,10 +211,10 @@ func (d *DetailView) Render(s state.ReadOnly) {
 
 	switch {
 	case s.IsPortscanning():
-		d.statusBar.Spinner().SetSuffix(" Port scanning...")
+		d.statusBar.Spinner().SetSuffix(" Port scanning")
 		d.statusBar.Spinner().Start(d.queue)
 	case s.IsDiscovering():
-		d.statusBar.Spinner().SetSuffix(" Discovering Devices...")
+		d.statusBar.Spinner().SetSuffix(" Discovering Devices")
 		d.statusBar.Spinner().Start(d.queue)
 	default:
 		d.statusBar.Spinner().Stop(d.queue)


### PR DESCRIPTION
This PR improves the UX a bit by:
- Highlighting the currently selected device
- Displaying a color to indicate status for "fresh" versus "stale" devices
- Removed the `...` from the spinners
- Added an elipses for the keybind hints on small screens