### PR TITLE
feat(alias): show the `alias` as well as the original `name` in the device detail view

### DIFF
--- a/internal/core/state/device_entry.go
+++ b/internal/core/state/device_entry.go
@@ -63,10 +63,6 @@ func (e *deviceEntry) SetAlias(alias string) {
 	e.alias = strings.TrimSpace(alias)
 }
 
-func (e *deviceEntry) ClearAlias() {
-	e.SetAlias("")
-}
-
 func (e *deviceEntry) ResetAlias() {
 	if e == nil {
 		return
@@ -80,14 +76,11 @@ func (e *deviceEntry) AliasMetadataLoaded() bool {
 	return e != nil && e.aliasMetadataLoaded
 }
 
-func (e *deviceEntry) PreferredName() string {
+func (e *deviceEntry) DetectedName() string {
 	if e == nil || e.device == nil {
 		return ""
 	}
 
-	if e.alias != "" {
-		return e.alias
-	}
 	if discoveredName := e.device.DisplayName(); discoveredName != "" {
 		return discoveredName
 	}

--- a/internal/core/state/state.go
+++ b/internal/core/state/state.go
@@ -18,7 +18,8 @@ type ReadOnly interface {
 	Selected() (*discovery.Device, bool)
 	SelectedIP() string
 	AliasFor(d *discovery.Device) string
-	PreferredNameFor(d *discovery.Device) string
+	DetectedNameFor(d *discovery.Device) string
+	AliasOrDetectedNameFor(d *discovery.Device) string
 	CurrentTheme() string
 	PreviousTheme() string
 	Version() string
@@ -172,8 +173,8 @@ func (s *AppState) AliasFor(d *discovery.Device) string {
 	return entry.Alias()
 }
 
-// PreferredNameFor returns the best available display name for a device.
-func (s *AppState) PreferredNameFor(d *discovery.Device) string {
+// AliasOrDetectedNameFor returns the detected name with alias override.
+func (s *AppState) AliasOrDetectedNameFor(d *discovery.Device) string {
 	if d == nil {
 		return ""
 	}
@@ -182,10 +183,29 @@ func (s *AppState) PreferredNameFor(d *discovery.Device) string {
 	defer s.mu.RUnlock()
 
 	if entry, ok := s.findDeviceEntryLocked(d); ok {
-		return entry.PreferredName()
+		if alias := entry.Alias(); alias != "" {
+			return alias
+		}
+		return entry.DetectedName()
 	}
 
-	return (&deviceEntry{device: d}).PreferredName()
+	return (&deviceEntry{device: d}).DetectedName()
+}
+
+// DetectedNameFor returns the device name without alias precedence.
+func (s *AppState) DetectedNameFor(d *discovery.Device) string {
+	if d == nil {
+		return ""
+	}
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	if entry, ok := s.findDeviceEntryLocked(d); ok {
+		return entry.DetectedName()
+	}
+
+	return (&deviceEntry{device: d}).DetectedName()
 }
 
 // SetCurrentTheme sets the current theme.

--- a/internal/core/state/state_test.go
+++ b/internal/core/state/state_test.go
@@ -185,7 +185,7 @@ func TestSearch(t *testing.T) {
 	}
 }
 
-func TestPreferredNameForAliasPrecedence(t *testing.T) {
+func TestAliasOrDetectedNameForAliasPrecedence(t *testing.T) {
 	t.Parallel()
 
 	appState := NewAppState(config.DefaultConfig(), "1.0.0")
@@ -195,8 +195,8 @@ func TestPreferredNameForAliasPrecedence(t *testing.T) {
 	device.SetDisplayName("Detected Device")
 	device.SetManufacturer("Acme")
 
-	if got := appState.PreferredNameFor(device); got != "Detected Device" {
-		t.Fatalf("PreferredNameFor() without alias = %q, want %q", got, "Detected Device")
+	if got := appState.AliasOrDetectedNameFor(device); got != "Detected Device" {
+		t.Fatalf("AliasOrDetectedNameFor() without alias = %q, want %q", got, "Detected Device")
 	}
 
 	appState.UpsertDevice(device)
@@ -205,26 +205,74 @@ func TestPreferredNameForAliasPrecedence(t *testing.T) {
 	if got := appState.AliasFor(device); got != "Desk Speaker" {
 		t.Fatalf("AliasFor() = %q, want %q", got, "Desk Speaker")
 	}
-	if got := appState.PreferredNameFor(device); got != "Desk Speaker" {
-		t.Fatalf("PreferredNameFor() with alias = %q, want %q", got, "Desk Speaker")
+	if got := appState.AliasOrDetectedNameFor(device); got != "Desk Speaker" {
+		t.Fatalf("AliasOrDetectedNameFor() with alias = %q, want %q", got, "Desk Speaker")
 	}
 }
 
-func TestPreferredNameForFallsBackToManufacturerAndIP(t *testing.T) {
+func TestAliasOrDetectedNameForFallsBackToManufacturerAndIP(t *testing.T) {
 	t.Parallel()
 
 	appState := NewAppState(config.DefaultConfig(), "1.0.0")
 
 	device := discovery.NewDevice(net.ParseIP("192.168.1.99"))
 	device.SetManufacturer("Vendor")
-	if got := appState.PreferredNameFor(device); got != "Vendor" {
-		t.Fatalf("PreferredNameFor() manufacturer fallback = %q, want %q", got, "Vendor")
+	if got := appState.AliasOrDetectedNameFor(device); got != "Vendor" {
+		t.Fatalf("AliasOrDetectedNameFor() manufacturer fallback = %q, want %q", got, "Vendor")
 	}
 
 	device.SetManufacturer("")
-	if got := appState.PreferredNameFor(device); got != "192.168.1.99" {
-		t.Fatalf("PreferredNameFor() IP fallback = %q, want %q", got, "192.168.1.99")
+	if got := appState.AliasOrDetectedNameFor(device); got != "192.168.1.99" {
+		t.Fatalf("AliasOrDetectedNameFor() IP fallback = %q, want %q", got, "192.168.1.99")
 	}
+}
+
+func TestDetectedNameForIgnoresAliasAndFallsBackToManufacturerAndIP(t *testing.T) {
+	t.Parallel()
+
+	t.Run("manufacturer fallback", func(t *testing.T) {
+		t.Parallel()
+
+		appState := NewAppState(config.DefaultConfig(), "1.0.0")
+		device := discovery.NewDevice(net.ParseIP("192.168.1.99"))
+		device.SetMAC("AA:BB:CC:DD:EE:99")
+		device.SetManufacturer("Vendor")
+		appState.UpsertDevice(device)
+		appState.SetAliasForMAC("aa:bb:cc:dd:ee:99", "Desk Speaker")
+
+		if got := appState.DetectedNameFor(device); got != "Vendor" {
+			t.Fatalf("DetectedNameFor() manufacturer fallback = %q, want %q", got, "Vendor")
+		}
+	})
+
+	t.Run("ip fallback", func(t *testing.T) {
+		t.Parallel()
+
+		appState := NewAppState(config.DefaultConfig(), "1.0.0")
+		device := discovery.NewDevice(net.ParseIP("192.168.1.99"))
+		device.SetMAC("AA:BB:CC:DD:EE:99")
+		appState.UpsertDevice(device)
+		appState.SetAliasForMAC("aa:bb:cc:dd:ee:99", "Desk Speaker")
+
+		if got := appState.DetectedNameFor(device); got != "192.168.1.99" {
+			t.Fatalf("DetectedNameFor() IP fallback = %q, want %q", got, "192.168.1.99")
+		}
+	})
+
+	t.Run("detected display name", func(t *testing.T) {
+		t.Parallel()
+
+		appState := NewAppState(config.DefaultConfig(), "1.0.0")
+		device := discovery.NewDevice(net.ParseIP("192.168.1.99"))
+		device.SetMAC("AA:BB:CC:DD:EE:99")
+		device.SetDisplayName("Detected Device")
+		appState.UpsertDevice(device)
+		appState.SetAliasForMAC("aa:bb:cc:dd:ee:99", "Desk Speaker")
+
+		if got := appState.DetectedNameFor(device); got != "Detected Device" {
+			t.Fatalf("DetectedNameFor() detected name = %q, want %q", got, "Detected Device")
+		}
+	})
 }
 
 func TestSetAliasMarksAliasLoaded(t *testing.T) {

--- a/internal/ui/components/device_table.go
+++ b/internal/ui/components/device_table.go
@@ -240,7 +240,7 @@ func (dt *DeviceTable) buildRows() []tableRow {
 		hostname := d.DisplayName()
 		alias := ""
 		if dt.state != nil {
-			hostname = dt.state.PreferredNameFor(d)
+			hostname = dt.state.AliasOrDetectedNameFor(d)
 			alias = dt.state.AliasFor(d)
 		}
 
@@ -267,7 +267,7 @@ func (dt *DeviceTable) refresh() {
 	dt.Clear()
 	const maxColWidth = 30
 
-	headers := []string{"IP", "Name", "MAC", "Manufacturer", "Last Seen"}
+	headers := []string{"IP", "Alias/Name", "MAC", "Manufacturer", "Last Seen"}
 
 	for i, h := range headers {
 		text := utils.Truncate(h, maxColWidth)

--- a/internal/ui/components/device_table_test.go
+++ b/internal/ui/components/device_table_test.go
@@ -30,6 +30,17 @@ func TestDeviceTableRenderUsesPreferredName(t *testing.T) {
 	}
 }
 
+func TestDeviceTableRenderUsesAliasNameHeader(t *testing.T) {
+	t.Parallel()
+
+	table := NewDeviceTable(nil)
+	table.Render(state.NewAppState(config.DefaultConfig(), "1.0.0").ReadOnly())
+
+	if got := table.GetCell(0, 1).Text; got != "Alias/Name" {
+		t.Fatalf("table header cell = %q, want %q", got, "Alias/Name")
+	}
+}
+
 func TestDeviceTableFilterMatchesAliasAndDetectedName(t *testing.T) {
 	t.Parallel()
 

--- a/internal/ui/views/detail.go
+++ b/internal/ui/views/detail.go
@@ -147,16 +147,13 @@ func (d *DetailView) Render(s state.ReadOnly) {
 		return t.Format("2006-01-02 15:04:05")
 	}
 
-	name := s.PreferredNameFor(device)
 	alias := s.AliasFor(device)
+	name := s.DetectedNameFor(device)
 
 	writeLine("IP", device.IP().String())
 	writeLine("Name", name)
 	if alias != "" {
 		writeLine("Alias", alias)
-		if detectedName := device.DisplayName(); detectedName != "" {
-			writeLine("Detected Name", detectedName)
-		}
 	}
 	writeLine("MAC", device.MAC())
 	writeLine("Manufacturer", device.Manufacturer())

--- a/internal/ui/views/detail_test.go
+++ b/internal/ui/views/detail_test.go
@@ -1,0 +1,63 @@
+package views
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/ramonvermeulen/whosthere/internal/core/config"
+	"github.com/ramonvermeulen/whosthere/internal/core/state"
+	"github.com/ramonvermeulen/whosthere/pkg/discovery"
+)
+
+func TestDetailViewRenderShowsAliasAndDetectedNameSeparately(t *testing.T) {
+	t.Parallel()
+
+	appState := state.NewAppState(config.DefaultConfig(), "1.0.0")
+	device := discovery.NewDevice(net.ParseIP("192.168.1.10"))
+	device.SetMAC("AA:BB:CC:DD:EE:FF")
+	device.SetDisplayName("Living Room TV")
+	appState.UpsertDevice(device)
+	appState.SetAliasForMAC("aa:bb:cc:dd:ee:ff", "TV Upstairs")
+	appState.SetSelectedIP("192.168.1.10")
+
+	view := NewDetailView(nil, func(func()) {})
+	view.Render(appState.ReadOnly())
+
+	text := view.info.GetText(true)
+	if !strings.Contains(text, "Name: Living Room TV") {
+		t.Fatalf("detail text missing detected name, got %q", text)
+	}
+	if !strings.Contains(text, "Alias: TV Upstairs") {
+		t.Fatalf("detail text missing alias, got %q", text)
+	}
+	if strings.Contains(text, "Name: TV Upstairs") {
+		t.Fatalf("detail text used alias as name, got %q", text)
+	}
+}
+
+func TestDetailViewRenderDoesNotUseAliasAsNameFallback(t *testing.T) {
+	t.Parallel()
+
+	appState := state.NewAppState(config.DefaultConfig(), "1.0.0")
+	device := discovery.NewDevice(net.ParseIP("192.168.1.11"))
+	device.SetMAC("AA:BB:CC:DD:EE:11")
+	device.SetManufacturer("Sony")
+	appState.UpsertDevice(device)
+	appState.SetAliasForMAC("aa:bb:cc:dd:ee:11", "Playstation")
+	appState.SetSelectedIP("192.168.1.11")
+
+	view := NewDetailView(nil, func(func()) {})
+	view.Render(appState.ReadOnly())
+
+	text := view.info.GetText(true)
+	if !strings.Contains(text, "Name: Sony") {
+		t.Fatalf("detail text missing manufacturer fallback name, got %q", text)
+	}
+	if !strings.Contains(text, "Alias: Playstation") {
+		t.Fatalf("detail text missing alias, got %q", text)
+	}
+	if strings.Contains(text, "Name: Playstation") {
+		t.Fatalf("detail text used alias as name fallback, got %q", text)
+	}
+}


### PR DESCRIPTION
Closes https://github.com/ramonvermeulen/whosthere/issues/116

Display both the original device `name` as well as the alias in the detail view when the device has an alias override. Apart from that this PR does some minor refactors around the alias override methods.