### PR TITLE
fix(dashboard): title color didn't update while switching themes

### DIFF
--- a/internal/ui/theme/theme.go
+++ b/internal/ui/theme/theme.go
@@ -1004,6 +1004,7 @@ func ApplyToPrimitive(p tview.Primitive) {
 		v.SetBordersColor(tview.Styles.BorderColor)
 		v.SetBackgroundColor(tview.Styles.PrimitiveBackgroundColor)
 		v.SetBorderColor(tview.Styles.BorderColor)
+		v.SetTitleColor(tview.Styles.TitleColor)
 		if currentNoColor {
 			if tview.Styles.PrimaryTextColor == tcell.ColorDefault {
 				selectedStyle := tcell.StyleDefault.Reverse(true)


### PR DESCRIPTION
<img width="193" height="49" alt="image" src="https://github.com/user-attachments/assets/1a3703fb-1fca-4523-9b9d-ba3112bfb67d" />

Fixes bug where the dashboard title color didn't update while switching themes.