### PR TITLE
feat: add mips64 build target for EdgeRouter 4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ dist
 
 manual_*_test.sh
 *.log
+
+# Cross-compiled binaries
+whosthere-linux-*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,8 +10,9 @@ builds:
   - main: ./main.go
     binary: whosthere
     goos: ["linux", "darwin", "windows"]
-    goarch: ["386", "amd64", "arm64", "arm"]
+    goarch: ["386", "amd64", "arm64", "arm", "mips64"]
     goarm: ["6", "7"]
+    gomips: ["hardfloat"]
     ignore:
       - goos: windows
         goarch: arm


### PR DESCRIPTION
Adds `mips64` (big-endian MIPS64) to the GoReleaser build matrix for cross-compilation to Ubiquiti EdgeRouter 4 (Cavium Octeon, Debian stretch).\n\n- Target: `GOOS=linux GOARCH=mips64 GOMIPS=hardfloat`\n- Verified: produces ELF 64-bit MSB MIPS-III, statically linked\n- Pre-built binary attached to [er4-build release](https://github.com/jelloeater-agent/whosthere/releases/tag/er4-build)